### PR TITLE
Update pages action

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -14,16 +14,35 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
+
       - name: Install requirements
         run:
           pip install -r requirements.txt
+
+      - name: Configure AWS Credentials for Epimorphics
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.BUILD_CEH_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BUILD_CEH_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Test pulling docker image
+        run: |
+          docker pull 293385631482.dkr.ecr.eu-west-1.amazonaws.com/epimorphics/record-spec-tools/unstable:1.0-SNAPSHOT
+
       - name: Build documentation
         run: |
           make dist
+
       - name: Upload static files as artifact
         id: deployment
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,55 @@
+name: publish model documentation
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  actions: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install requirements
+        run:
+          pip install -r requirements.txt
+
+      - name: Configure AWS Credentials for Epimorphics
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.BUILD_CEH_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.BUILD_CEH_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Test pulling docker image
+        run: |
+          docker pull 293385631482.dkr.ecr.eu-west-1.amazonaws.com/epimorphics/record-spec-tools/unstable:1.0-SNAPSHOT
+
+      - name: Build release packages
+        run: |
+          make release
+      
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          draft: true
+          prerelease: true
+          files: |
+            release/*

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+Upcoming (DRAFT 0.4)
+--------------------
+

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ dist: validate doc schemas contexts
 	cp -R samples/* build
 	cp schema/fdri.recordspec.yaml build/schema
 
+doc: doc/html/index.html
 schemas: $(SCHEMAS)
 contexts: $(CONTEXTS)
 samples: $(SAMPLES)
@@ -66,7 +67,7 @@ clean:
 build:
 	mkdir -p build
 
-doc:
+doc/html/index.html: doc/*.md owl/fdri-metadata.ttl
 	python make_doc.py
 
 $(SCHEMA_BASE):

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ dist: validate doc schemas contexts
 	cp schema/fdri.recordspec.yaml build/schema
 
 doc: doc/html/index.html
+release: build/release/doc/index.html build/release/fdri.recordspec.yaml build/release/fdri-metadata.ttl build/release/CHANGELOG.txt
 schemas: $(SCHEMAS)
 contexts: $(CONTEXTS)
 samples: $(SAMPLES)
@@ -82,3 +83,18 @@ build/shacl:
 build/data:
 	mkdir -p build/data
 
+build/release/doc/index.html: doc/html/index.html
+	mkdir -p build/release/doc
+	cp doc/html/* build/release/doc
+
+build/release/CHANGELOG.txt: CHANGELOG.txt
+	mkdir -p build/release
+	cp $^ build/release
+
+build/release/fdri.recordspec.yaml: schema/fdri.recordspec.yaml
+	mkdir -p build/release
+	cp $^ build/release
+
+build/release/fdri-metadata.ttl: owl/fdri-metadata.ttl
+	mkdir -p build/release
+	cp $^ build/release


### PR DESCRIPTION
Add workflows for updating GH pages and for building a release. The former is only run on a manual trigger. The latter runs on a push of a tag with starts `v`.