### PR TITLE
Add fdri:valueType property (#23)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+Ticket numbers referenced in the CHANGELOG refer to issues in the GitHub repository at https://github.com/NERC-CEH/fdri-ontology/issues
+
+DRAFT 0.4.1
+-----------
+
+* NEW: Added property `fdri:valueType` which can be used on a `schema:PropertyValue` to convey the datatype or class of the value of the property. (#23)
+
 DRAFT 0.4
 ---------
 

--- a/owl/catalog-v001.xml
+++ b/owl/catalog-v001.xml
@@ -10,6 +10,6 @@
     <uri id="Imports Wizard Entry" name="http://www.w3.org/ns/ssn/" uri="https://www.w3.org/ns/ssn/"/>
     <uri id="User Edited Redirect" name="http://www.w3.org/ns/dcat3" uri="dcat3.ttl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1749045084756" name="http://data.ordnancesurvey.co.uk/ontology/spatialrelations/" uri="spatialrelations.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1750412449480" name="http://data.ordnancesurvey.co.uk/ontology/spatialrelations/" uri="spatialrelations.owl"/>
     </group>
 </catalog>

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -26,7 +26,7 @@
                                                     <https://w3id.org/iadopt/ont/1.0.3> ;
                                         rdfs:comment "An ontology for the recording of dataset metadata, provenance information and related reference data for use in the fine-grained metadata store element of the FDRI project."@en ;
                                         rdfs:label "FDRI Fine-grained Metadata Store Ontology"@en ;
-                                        owl:versionInfo "0.3 DRAFT (In Progress)" .
+                                        owl:versionInfo "0.4.1 DRAFT" .
 
 #################################################################
 #    Annotation properties
@@ -427,6 +427,14 @@ When `fdri:hasValue` is present on an item, this property SHOULD NOT be present 
                 rdfs:range :ValueStatistic ;
                 rdfs:comment "Relates an aggregated data resource to the type of aggregation applied."@en ;
                 rdfs:label "value statistic"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/valueType
+:valueType rdf:type owl:ObjectProperty ;
+           rdfs:comment """The type of the value of the enclosing resource.
+
+On a schema:PropertyValue resource, the value of this property should be the IRI of the datatype of `minValue`, `maxValue` and/or `value` or the IRI of the class of the resource referenced by `valueReference`."""@en ;
+           rdfs:label "value type"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/variable
@@ -1862,6 +1870,10 @@ A Time-Series Definition captures the information that is common across multiple
 ###  http://schema.org/PropertyValue
 schema:PropertyValue rdf:type owl:Class ;
                      rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                       owl:onProperty :valueType ;
+                                       owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
                                        owl:onProperty schema:unit ;
                                        owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                      ] ,

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -2677,6 +2677,18 @@ records:
             lang: en
         propertyUri: schema:valueReference
         kind: object
+      valueType:
+        label:
+          - value: value type
+            lang: en
+        description:
+          - value: |
+              The type of the value of the enclosing resource.
+
+              On a `schema:PropertyValue` resource, the value of this property should be the IRI of the datatype of
+              `minValue`, `maxValue` and/or `value` or the IRI of the class of the resource referenced by `valueReference`.
+        propertyUri: fdri:valueType
+        kind: object
       unit:
         label:
           - value: unit


### PR DESCRIPTION
Add `fdri:valueType` as an open-range object property. 
Allow max 1 `fdri:valueType` on `schema:PropertyValue`
Add `valueType` property to the `PropertyValue` record in recordspec as an optional non-repeatable property.