### PR TITLE
Add SOSA/SSN Systems Module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ RECORDS = \
 	Activity \
 	Aggregation \
 	ConfigurationItem \
+	Condition \
 	EnvironmentalMonitoringPlatform \
 	EnvironmentalMonitoringSensor \
 	EnvironmentalMonitoringSite \
@@ -17,8 +18,12 @@ RECORDS = \
 	GeospatialFeatureOfInterest \
 	InternalDataProcessingConfiguration \
 	Measure \
+	OperatingRange \
 	Procedure \
 	StaticDeployment \
+	SurvivalRange \
+	SystemCapability \
+	SystemProperty \
 	TimeSeriesDataset \
 	TimeSeriesDefinition \
 	Variable

--- a/doc/sensor-capabilities.md
+++ b/doc/sensor-capabilities.md
@@ -1,0 +1,245 @@
+## System Capabilities and Ranges
+
+The FDRI data model extends the [SOSA/SSN System Capabilities Module](https://www.w3.org/TR/vocab-ssn/#System-capabilities) to provide a way to capture information about the range of conditions under which a sensor can be operational, and to associate sensor-related operational properties such as sensitivity, accurracy and frequency with those operational ranges. Typically this model will be used to record the manufacturer's specification of the operational properties of a make/model of sensor under a manufacturer-defined "normal" operating condition.
+
+```mermaid
+classDiagram
+    direction LR
+    class EMSystemType["fdri:EnvironmentalMonitoringSystemType"]
+    class Variable["fdri:Variable"]
+    class Condition["fdri:Condition"]
+    class SystemCapability["fdri:SystemCapability"]
+    class OperatingRange["fdri:OperatingRange"]
+    class SurvivalRange["fdri:SurvivalRange"]
+
+    EMSystemType --> "0..*" SystemCapability: sys_hasSystemCapability
+    EMSystemType --> "0..*" SurvivalRange: sys_hasSurvivalRange
+    EMSystemType --> "0..*" OperatingRange: sys_hasOperatingRange
+    SystemCapability --> "1" Variable: ssn_forProperty
+    SystemCapability --> "0..*" Condition: sys_inCondition
+    OperatingRange --> "0..*" Condition: sys_inCondition
+    SurvivalRange --> "0..*" Condition: sys_inCondition
+```
+
+### Conditions
+
+Conditions define constraints on the environment in which a sensor operates and are used to set out the environmental conditions under which a given `fdri:SystemCapability`, `fdri:SurvivalRange` or `fdri:OperatingRange` apply.
+
+An `fdri:Condition` has the following properties:
+
+* `fdri:property` references an `fdri:Variable` which specifies the observed property of the environment for the condition.
+* `schema:value`, `schema:minValue`, `schema:maxValue` - a single value or, more typically, a value range for the property
+* `fdri:unit` - an `fdri:Unit` specifying the unit of measure of the value or value range.
+
+```mermaid
+classDiagram
+class Condition["fdri:Condition"] {
+    schema:minValue: rdfs:Literal
+    schema:maxValue: rdfs:Literal
+    schema:value: rdfsLiteral
+}
+class Unit["fdri:Unit"]
+class Variable["fdri:Variable"]
+Condition --> Variable: fdri_property
+Condition --> Unit: fdri_unit
+```
+
+For example, a condition of an air temperature between -40&deg;C and +80&deg;C can be represented as shown in the diagram below:
+
+```mermaid
+flowchart
+taCond["Condition: Air Temperature -40 to +80 degrees C"]
+ta["Air Temperature"]
+degc["Degrees Celsius"]
+taCond --property--> ta
+taCond --minValue--> taMin["-40.0"]
+taCond --maxValue--> taMax["80.0"]
+taCond --unit--> degc
+```
+
+### System Capability
+
+A `sys:SystemCapability` provides a specification of the capability of a system to perform its primary purpose. For sensors, this primary purpose is the observation of some `fdri:Variable`. 
+
+A `sys:SystemCapability` may be associated with either an `fdri:EnvironmentalMonintoringSystemType`, or with an `fdri:EnvironmentalMonintorigSystem` using the property `sys:hasSystemCapability`. In the former case, the capabilities are interpreted as applying to all systems of that type, and in the latter case as applying only to that specific system instance. 
+
+`sys:SystemCapability` has the following properties:
+
+* `ssn:forProperty` references an `fdri:Variable` which defines the environmental variable measured by the sensor that this capability applies to.
+* `sys:inCondition` references any number of `fdri:Condition` which specify the environmental conditions under which the given value of the capability characteristics will apply.
+* `sys:hasSystemProperty` property references one or more `fdri:SystemProperty` resources each of which provides values for one of the characteristics of the sensor for the specified variable, under the specified conditions.
+
+An `fdri:SystemProperty` provides the value of one capability characteristics. It has the following properties:
+
+* `fdri:property` references an `fdri:Variable` which defines the sensor characteristic (e.g. accuracy, sensitivity, repeatablility).
+* `schema:value`, `schema:minValue`, `schema:maxValue` - a single value or, more typically, a value range for the characteristic,
+* `fdri:unit` - an `fdri:Unit` specifying the unit of measure of the value or value range.
+
+```mermaid
+classDiagram
+    class SystemCapability["sys:SystemCapability"]
+    class Variable["fdri:Variable"]
+    class SystemProperty["fdri:SystemProperty"] {
+        minValue: rdfs:Literal
+        maxValue: rdfs:Literal
+        value: rdfs:Literal
+    }
+    class Condition["sys:Condition"]
+    class Unit["fdri:Unit"]
+    SystemCapability "0..*" --> "1" Variable: ssn_forProperty
+    SystemCapability "0..*" --> "0..*" Condition: sys_inCondition
+    SystemCapability "0..*" --> "1..*" SystemProperty: sys_hasSystemProperty
+    SystemProperty "0..*" --> "1" Variable: fdri_property
+    SystemProperty "0..*" --> "1" Unit: fdri_unit
+```
+
+The example below shows an imagined air temperature sensor and its capability. In this example the sensor under its normal operating range has an accuracy of +/- 0.5 degrees celsius, and a sensitivity of 0.1 degrees celsius.
+
+```mermaid
+flowchart
+ta["`Air Temperature
+&lt;&lt;fdri:Variable&gt;&gt;`"]
+taOp["`Temperature -40 to +80
+&lt;&lt;fdri:Condition&gt;&gt;`"]
+taAcc["`TempMaster Accurracy
+&lt;&lt;fdri:SystemProperty&gt;&gt;`"]
+taSen["`TempMaster Sensitivity
+&lt;&lt;fdri:SystemProperty&gt;&gt;`"]
+acc["`Accuracy
+&lt;&lt;fdri:Variable&gt;&gt;`"]
+sen["`Sensitivity
+&lt;&lt;fdri:Variable&gt;&gt;`"]
+degc["`Degree Celsius
+&lt;&lt;fdri:Unit&gt;&gt;`"]
+taSensor["`TempMaster
+&lt;&lt;fdri:EMSystemType&gt;&gt;`"] --hasSystemCapability--> taCap
+taCap["`Temp Master Capability
+&lt;&lt;fdri:SystemCapability&gt;&gt;`"] --forProperty--> ta
+taCap --inCondition--> taOp
+taCap --hasSystemProperty--> taAcc
+taCap --hasSystemProperty--> taSen
+taAcc --property--> acc
+taAcc --minValue--> taAccMin["-0.5"]
+taAcc --maxValue--> taAccMax["+0.5"]
+taAcc --unit--> degc
+taSen --property--> sen
+taSen --value--> taSenVal["0.1"]
+taSen --unit--> degc
+taOp --minValue--> taOpMin["-40"]
+taOp --maxValue--> taOpMax["80"]
+taOp --unit--> degc
+```
+
+### Operating Range
+
+An `fdri:OperatingRange` specifies the operational characteristics of a system. It can be used either to specify quality values for specific operational characteristics such as "maintenance schedule" or "operating voltage range", or it can be used without any such characteristics. If no operational characteristics are defined on an `fdri:OperatingRange`, then the resource is interepreted as specifying the conditions under which the system will operate normally. When conditions go beyond the specified ranges, a system is considered to be operating "out of range", which may affect the quality of its observations.
+
+`fdri:OperatingRange` has the following properties:
+* `sys:hasOperatingProperty` optionally references the `fdri:Variable` which defines the operational characteristic that this operating range provides a value for.
+* `sys:inCondition` references the `fdri:Condition` resources that define the environmental conditions for this operating range.
+* `schema:value`, `schema:minValue`, `schema:maxValue` - a single value or, more typically, a value range for the characteristic (if one is provided).
+* `fdri:unit` - an `fdri:Unit` specifying the unit of measure of the value or value range (if one is provided).
+
+```mermaid
+classDiagram
+    class OperatingRange["fdri:OperatingRange"] {
+        schema:minValue: rdfs:Literal
+        schema:maxValue: rdfs:Literal
+        schema:value: rdfs:Literal
+    }
+    class Condition["fdri:Condition"]
+    class Variable["fdri:Variable"]
+    class Unit["fdri:Unit"]
+    OperatingRange "0..*" --> "0..1" Variable: sys_hasOperatingProperty
+    OperatingRange "0..*" --> "0..1" Unit: schema_unit
+    OperatingRange "0..*" --> "1..*" Condition: sys_inCondition
+```
+
+The example below shows a statement that the fictional "TempMaster" sensor is expected to operate normally under a temperature range of -40&deg;C to 80&deg;C.
+
+```mermaid
+flowchart
+ta["`Air Temperature
+&lt;&lt;fdri:Variable&gt;&gt;`"]
+taCond["`Temperature -40 to +80
+&lt;&lt;fdri:Condition&gt;&gt;`"]
+taOp["`TempMaster Operating Range
+&lt;&lt;fdri:OperatingRange&gt;&gt;`"]
+taSensor["`TempMaster
+&lt;&lt;fdri:EMSystemType&gt;&gt;`"]
+degc["`Degree Celsius
+&lt;&lt;fdri:Unit&gt;&gt;`"]
+
+taSensor --hasOperatingRange--> taOp
+taOp --inCondition--> taCond
+taCond --property--> ta
+taCond --minValue--> min["-40"]
+taCond --maxValue--> max["80"]
+taCond --unit--> degc
+
+```
+
+### Survival Range
+
+An `fdri:SurvivalRange` specifies operational lifetime characteristics of a system under certain environmental conditions. It can be used either to provide values of specific lifetime characteristics (e.g. battery lifetime), or it can be used without any characteristics. If used without any characteristics, the `fdri:SurvivalRange` specifies the environmental conditions under which a system remains undamaged. When those conditions are exceeded, the system is considered damaged in some way and in need of maintenance or replacement.
+
+The structure of `fdri:SurvivalRange` is similar to that of `fdri:OperatingRange`:
+* `sys:hasSurvivalProperty` optionally references the `fdri:Variable` which defines the lifetime characteristic that this survival range provides a value for.
+* `sys:inCondition` references the `fdri:Condition` resources that define the environmental conditions for this survival range.
+* `schema:value`, `schema:minValue`, `schema:maxValue` - a single value or, more typically, a value range for the characteristic (if one is provided).
+* `fdri:unit` - an `fdri:Unit` specifying the unit of measure of the value or value range (if one is provided).
+
+```mermaid
+classDiagram
+    class OperatingRange["fdri:SurvivalRange"] {
+        schema:minValue: rdfs:Literal
+        schema:maxValue: rdfs:Literal
+        schema:value: rdfs:Literal
+    }
+    class Condition["fdri:Condition"]
+    class Variable["fdri:Variable"]
+    class Unit["fdri:Unit"]
+    OperatingRange "0..*" --> "0..1" Variable: sys_hasSurvivalProperty
+    OperatingRange "0..*" --> "0..1" Unit: schema_unit
+    OperatingRange "0..*" --> "1..*" Condition: sys_inCondition
+```
+
+The following example shows a battery lifetime of 800 days for an imaginary "TempMaster" sensor under its normal operating conditions of -40&deg;C to +80&deg;C.
+
+```mermaid
+flowchart
+ta["`Air Temperature
+&lt;&lt;fdri:Variable&gt;&gt;`"]
+battLife["`Battery Lifetime
+&lt;&lt;fdri:Variable&gt;&gt;`"]
+taCond["`Temperature -40 to +80
+&lt;&lt;fdri:Condition&gt;&gt;`"]
+taSurv["`TempMaster Battery Lifetime
+&lt;&lt;fdri:SurvivalRange&gt;&gt;`"]
+taSensor["`TempMaster
+&lt;&lt;fdri:EMSystemType&gt;&gt;`"]
+degc["`Degree Celsius
+&lt;&lt;fdri:Unit&gt;&gt;`"]
+days["`Days
+&lt;&lt;fdri:Unit&gt;&gt;`"]
+
+taSensor --hasSurvivalRange--> taSurv
+taSurv --hasSurvivalProperty--> battLife
+taSurv --inCondition--> taCond
+taSurv --value--> 800
+taSurv --unit--> days
+taCond --property--> ta
+taCond --minValue--> min["-40"]
+taCond --maxValue--> max["80"]
+taCond --unit--> degc
+
+```
+
+
+### Note on SOSA/SSN Systems Module Mapping
+
+ The modelling for `fdri:Condition` extends the SOSA/SSN `sys:Condition`. Under the SOSA/SSN model the class `sys:Condition` is declared as a subclass of `ssn:Property`. This is still true in the FDRI model, but rather than the condition property being inferred by the class of the condition, the property is explicitly stated using the `fdri:property` property. We believe this gives greater clarity and flexibility as it allows condition properties to be drawn from a controlled vocabulary of `fdri:Variable` instances rather than requiring new classes to be defined for each condition property.
+ 
+The same approach has been taken for including `sys:SystemProperty` (extended as `fdri:SystemProperty`).
+
+The FDRI model also makes explicit the use of properties from the domain of `schema:PropertyValue` to capture values and ranges of values on the classes `fdri:SurvivalRange` (derived from `sys:SurvivalRange`), `fdri:OperatingRange` (derived from `sys:OperatingRange`), and `fdri:Condition` (from `sys:Condition`).

--- a/doc/toc.md
+++ b/doc/toc.md
@@ -19,5 +19,6 @@
 * [Environmental Monitoring Facility Model](emf.md)
 * [Deployment Model](deployments.md)
 * [Sensor/System Model](sensor-system.md)
+* [Sensor/System Capabilities Model](sensor-capabilities.md)
 * [Data-processing Configuration Model](data-processing-configurations.md)
 * [OGC Connected Systems Spec Mapping](ogc-connected-systems.md)

--- a/make_doc.py
+++ b/make_doc.py
@@ -109,6 +109,7 @@ if __name__ == '__main__':
     html += make_section('doc/emf.md')
     html += make_section('doc/deployments.md')
     html += make_section('doc/sensor-system.md')
+    html += make_section('doc/sensor-capabilities.md')
     html += make_section('doc/data-processing-configurations.md')
     html += make_section('doc/geospatial.md')
     html += make_reference_doc()

--- a/owl/catalog-v001.xml
+++ b/owl/catalog-v001.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="Imports Wizard Entry" name="http://www.w3.org/ns/ssn/systems/" uri="http://www.w3.org/ns/ssn/systems"/>
     <uri id="User Edited Redirect" name="http://www.opengis.net/ont/geosparql" uri="geo.ttl"/>
     <uri id="Imports Wizard Entry" name="http://data.ordnancesurvey.co.uk/ontology/spatialrelations/" uri="https://www.ordnancesurvey.co.uk/linked-data/ontology/spatialrelations.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.org/dc/terms/" uri="dublin_core_terms.ttl"/>

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -735,6 +735,21 @@ More specific sub-properties `fdri:dependencyNote` and `fdri:deploymentVariance`
           rdfs:label "unit name"@en .
 
 
+###  http://schema.org/maxValue
+schema:maxValue rdf:type owl:DatatypeProperty ;
+                rdfs:range rdfs:Literal .
+
+
+###  http://schema.org/minValue
+schema:minValue rdf:type owl:DatatypeProperty ;
+                rdfs:range rdfs:Literal .
+
+
+###  http://schema.org/value
+schema:value rdf:type owl:DatatypeProperty ;
+             rdfs:range rdfs:Literal .
+
+
 ###  http://www.w3.org/2003/01/geo/wgs84_pos#lat
 geo:lat rdf:type owl:DatatypeProperty ;
         rdfs:domain geo:SpatialThing ;
@@ -823,6 +838,37 @@ Each Annotation instance provides either a single value (`fdri:hasValue`) or a t
                  rdfs:subClassOf skos:ConceptScheme ;
                  rdfs:comment "A concept scheme consisting of Catchment concepts."@en ;
                  rdfs:label "Catchment Scheme"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/Condition
+:Condition rdf:type owl:Class ;
+           rdfs:subClassOf :PropertyValue ,
+                           <http://www.w3.org/ns/ssn/systems/Condition> ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty :property ;
+                             owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                             owl:onClass :Variable
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty schema:unit ;
+                             owl:cardinality "1"^^xsd:nonNegativeInteger
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty schema:maxValue ;
+                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty schema:minValue ;
+                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                           ] ,
+                           [ rdf:type owl:Restriction ;
+                             owl:onProperty schema:value ;
+                             owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                           ] ;
+           rdfs:comment """Used to specify ranges for qualities that act as conditions on a system/sensor's operation.  For example, wind speed of 10-60m/s may be used as the condition on a SystemProperty, for example, to state that a sensor has a particular accuracy in that condition.
+
+The `fdri:property` property references the `fdri:Variable` that defines the condition property. The properties `schema:minValue` and `schema:maxValue` may be used to express a value range for the condition, or the property `schema:value` used to express a single value. The property `schema:unit` MUST also be used to express the unit of measure for the condition."""@en ;
+           rdfs:label "Condition" .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/ConfigurationArgument
@@ -1621,6 +1667,35 @@ It is recommended that every dataset should specify the feature(s) of interest (
                           rdfs:label "Observation Dataset Series"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/OperatingRange
+:OperatingRange rdf:type owl:Class ;
+                rdfs:subClassOf <http://www.w3.org/ns/ssn/systems/OperatingRange> ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty schema:unit ;
+                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onClass <http://qudt.org/schema/qudt/Unit>
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty <http://www.w3.org/ns/ssn/systems/hasOperatingProperty> ;
+                                  owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onClass :Variable
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty schema:maxValue ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty schema:minValue ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty schema:value ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ;
+                rdfs:comment "The FDRI ontology extends the SOSA/SSN class `ssn-system:OperatingRange` to restrict the range of `ssn-system:hasOperatingProperty` to `fdri:Varaible` as well as to make explicit the use of `schema:minValue`, `schema:maxValue`, `schema:value` and `schema:unit` to capture the survival property value and unit of measure."@en ;
+                rdfs:label "Operating Range"@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/Organization
 :Organization rdf:type owl:Class ;
               rdfs:subClassOf :Agent ;
@@ -1853,6 +1928,64 @@ The periodicity (`fdri:procedurePeriodicity`) property SHOULD be used to capture
                                   ] ;
                   rdfs:comment "A deployment of a sensor or system of sensors in a fixed relationship to some location."@en ;
                   rdfs:label "Static Deploment"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/SurvivalRange
+:SurvivalRange rdf:type owl:Class ;
+               rdfs:subClassOf <http://www.w3.org/ns/ssn/systems/SurvivalRange> ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty schema:unit ;
+                                 owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                 owl:onClass <http://qudt.org/schema/qudt/Unit>
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty <http://www.w3.org/ns/ssn/systems/hasSurvivalProperty> ;
+                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                 owl:onClass :Variable
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty schema:maxValue ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty schema:minValue ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty schema:value ;
+                                 owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                               ] ;
+               rdfs:comment "The FDRI ontology extends the SOSA/SSN class `ssn-system:SurvivalRange` to restrict the range of `ssn-system:hasSurvivalProperty` to `fdri:Varaible` as well as to make explicit the use of `schema:minValue`, `schema:maxValue`, `schema:value` and `schema:unit` to capture the survival property value and unit of measure.en"@en ;
+               rdfs:label "Survival Range"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/SystemProperty
+:SystemProperty rdf:type owl:Class ;
+                rdfs:subClassOf <http://www.w3.org/ns/ssn/systems/SystemProperty> ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :property ;
+                                  owl:cardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty schema:unit ;
+                                  owl:cardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty schema:maxValue ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty schema:minValue ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty schema:value ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ;
+                rdfs:comment """The FDRI ontology definition of System Property extends the SOSA/SSN `ssn-system:SystemProperty` to use the property `fdri:Property` to reference the `fdri:Variable` that defines the system characteristic being measured.
+
+In addition the use of `schema:minValue`, `schema:maxValue`, `schema:value` and `schema:unit` to capture the characteristic value is made explicity on this class."""@en ;
+                rdfs:label "System Property"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/SystemStatus

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -23,6 +23,7 @@
                                                     <http://www.w3.org/2006/time#2016> ,
                                                     <http://www.w3.org/ns/dcat3> ,
                                                     ssn:ext ,
+                                                    <http://www.w3.org/ns/ssn/systems/> ,
                                                     <https://w3id.org/iadopt/ont/1.0.3> ;
                                         rdfs:comment "An ontology for the recording of dataset metadata, provenance information and related reference data for use in the fine-grained metadata store element of the FDRI project."@en ;
                                         rdfs:label "FDRI Fine-grained Metadata Store Ontology"@en ;
@@ -1288,7 +1289,31 @@ If information is available regarding the platforms (`fdri:EnvironmentalMonitori
                                                      owl:allValuesFrom :Procedure
                                                    ] ,
                                                    [ rdf:type owl:Restriction ;
+                                                     owl:onProperty <http://www.w3.org/ns/ssn/systems/hasOperatingRange> ;
+                                                     owl:allValuesFrom <http://www.w3.org/ns/ssn/systems/OperatingRange>
+                                                   ] ,
+                                                   [ rdf:type owl:Restriction ;
+                                                     owl:onProperty <http://www.w3.org/ns/ssn/systems/hasSurvivalRange> ;
+                                                     owl:allValuesFrom <http://www.w3.org/ns/ssn/systems/SurvivalRange>
+                                                   ] ,
+                                                   [ rdf:type owl:Restriction ;
+                                                     owl:onProperty <http://www.w3.org/ns/ssn/systems/hasSystemCapability> ;
+                                                     owl:allValuesFrom <http://www.w3.org/ns/ssn/systems/SystemCapability>
+                                                   ] ,
+                                                   [ rdf:type owl:Restriction ;
                                                      owl:onProperty :hasProcedure ;
+                                                     owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                                   ] ,
+                                                   [ rdf:type owl:Restriction ;
+                                                     owl:onProperty <http://www.w3.org/ns/ssn/systems/hasOperatingRange> ;
+                                                     owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                                   ] ,
+                                                   [ rdf:type owl:Restriction ;
+                                                     owl:onProperty <http://www.w3.org/ns/ssn/systems/hasSurvivalRange> ;
+                                                     owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                                   ] ,
+                                                   [ rdf:type owl:Restriction ;
+                                                     owl:onProperty <http://www.w3.org/ns/ssn/systems/hasSystemCapability> ;
                                                      owl:minCardinality "0"^^xsd:nonNegativeInteger
                                                    ] ,
                                                    [ rdf:type owl:Restriction ;

--- a/samples/id/condition/hmp155-normal-temperature.jsonld
+++ b/samples/id/condition/hmp155-normal-temperature.jsonld
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../schema/Condition.schema.json",
+    "@id": "http://fdri.ceh.ac.uk/id/condition/hmp155-normal-temperature",
+    "@type": "http://fdri.ceh.ac.uk/vocab/metadata/Condition",
+    "property": {"@id": "http://fdri.ceh.ac.uk/ref/common/variable/ta"},
+    "minValue": {"@value": "-40.0", "@type": "xsd:decimal"},
+    "maxValue": {"@value": "80.0", "@type": "xsd:decimal"},
+    "unit": {"@id": "http://fdri.ceh.ac.uk/ref/common/unit/degc"}
+}

--- a/samples/id/operating-range/hmp155.jsonld
+++ b/samples/id/operating-range/hmp155.jsonld
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../schema/OperatingRange.schema.json",
+    "@id": "http://fdri.ceh.ac.uk/id/operating-range/hmp155",
+    "@type": "http://fdri.ceh.ac.uk/vocab/metadata/OperatingRange",
+    "inCondition": [
+        {"@id": "http://fdri.ceh.ac.uk/id/condition/hmp155-normal-temperature"},
+        {"@id": "http://fdri.ceh.ac.uk/id/condition/hmp155-normal-humidity"}
+    ]
+}

--- a/samples/id/survival-range/hmp-155.jsonld
+++ b/samples/id/survival-range/hmp-155.jsonld
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../schema/SurvivalRange.schema.json",
+    "@id": "http://fdri.ceh.ac.uk/id/survival-range/hmp155",
+    "@type": "http://fdri.ceh.ac.uk/vocab/metadata/SurvivalRange",
+    "inCondition": [{"@id": "http://fdri.ceh.ac.uk/id/condition/hmp155-normal-temperature"}]
+}

--- a/samples/id/system-capability/hmp155.jsonld
+++ b/samples/id/system-capability/hmp155.jsonld
@@ -1,0 +1,35 @@
+{
+    "$schema": "../../schema/SystemCapability.schema.json",
+    "@id": "http://fdri.ceh.ac.uk/id/system-capability/hmp155",
+    "@type": "http://www.w3.org/ns/ssn/systems/SystemCapability",
+    "inCondition": {"@id": "http://fdri.ceh.ac.uk/id/condition/hmp155-normal-temperature"},
+    "forProperty": [{"@id": "http://fdri.ceh.ac.uk/ref/common/variable/ta"}],
+    "hasSystemProperty": [
+        {
+            "@type": "http://fdri.ceh.ac.uk/vocab/metadata/SystemProperty",
+            "property": {"@id": "http://fdri.ceh.ac.uk/ref/common/system-property/accuracy"},
+            "minValue": {"@value": "-0.5", "@type": "http://www.w3.org/2001/XMLSchema#decimal"},
+            "maxValue": {"@value": "0.5", "@type": "http://www.w3.org/2001/XMLSchema#decimal"},
+            "unit": {"@id": "http://fdri.ceh.ac.uk/ref/common/unit/degc"}
+        },
+        {
+            "@type": "http://fdri.ceh.ac.uk/vocab/metadata/SystemProperty",
+            "property": {"@id": "http://fdri.ceh.ac.uk/ref/common/system-property/sensitivity"},
+            "value": {"@value": "0.1", "@type": "http://www.w3.org/2001/XMLSchema#decimal"},
+            "unit": {"@id": "http://fdri.ceh.ac.uk/ref/common/unit/degc"}
+        },
+        {
+            "@type": "http://fdri.ceh.ac.uk/vocab/metadata/SystemProperty",
+            "property": {"@id": "http://fdri.ceh.ac.uk/ref/common/system-property/precision"},
+            "minValue": {"@value": "-0.2", "@type": "http://www.w3.org/2001/XMLSchema#decimal"},
+            "maxValue": {"@value": "0.2", "@type": "http://www.w3.org/2001/XMLSchema#decimal"},
+            "unit": {"@id": "http://fdri.ceh.ac.uk/ref/common/unit/degc"}
+        },
+        {
+            "@type": "http://fdri.ceh.ac.uk/vocab/metadata/SystemProperty",
+            "property": {"@id": "http://fdri.ceh.ac.uk/ref/common/system-property/frequency"},
+            "value": {"@value": "2.0", "@type": "http://www.w3.org/2001/XMLSchema#decimal"},
+            "unit": {"@id": "http://fdri.ceh.ac.uk/ref/common/unit/sec"}
+        }
+    ]
+}

--- a/samples/ref/common/sensor-type/hmp155.jsonld
+++ b/samples/ref/common/sensor-type/hmp155.jsonld
@@ -16,5 +16,14 @@
         "hasRole": {"@id": "http://fdri.ceh.ac.uk/ref/common/related-party-role/manufacturer"}
     }],
     "hasProcedure": [{"@id": "http://fdri.ceh.ac.uk/id/procedure/cosmos-sampling-regime-ta.jsonld"}],
-    "settleInPeriod": "PT24H"
+    "settleInPeriod": "PT24H",
+    "hasSystemCapability": [
+        {"@id": "http://fdri.ceh.ac.uk/id/system-capability/hmp155"}
+    ],
+    "hasOperatingRange": [
+        { "@id": "http://fdri.ceh.ac.uk/id/operating-range/hmp155" }
+    ],
+    "hasSurvivalRange": [
+        {"@id": "http://fdri.ceh.ac.uk/id/survival-range/hmp155"}
+    ]
 }

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -30,6 +30,8 @@ prefixes:
     uri: http://data.ordnancesurvey.co.uk/ontology/spatialrelations/
   - prefix: ssn
     uri: http://www.w3.org/ns/ssn/
+  - prefix: sys
+    uri: http://www.w3.org/ns/ssn/systems/
   - prefix: xsd
     uri: http://www.w3.org/2001/XMLSchema#
 
@@ -388,6 +390,51 @@ mixins:
         constraints:
           - datatype: xsd:string
 
+  WithValueOrRange:
+    label:
+      - value: With Value or Range
+        lang: en
+    description:
+      - value: |
+          Provides properties for recording either a single value or a value range with a required unit of measure.
+    properties:
+      minValue:
+        label:
+          - value: minimum
+            lang: en
+        description:
+          - value: The lower bound of a range value.
+            lang: en
+        propertyUri: schema:minValue
+        kind: literal
+      maxValue:
+        label:
+          - value: maximum
+            lang: en
+        description:
+          - value: The upper bound of a range value.
+            lang: en
+        propertyUri: schema:maxValue
+        kind: literal
+      value:
+        label:
+          - value: value
+            lang: en
+        description:
+          - value: The scalar or string literal value
+        propertyUri: schema:value
+        kind: literal
+      unit:
+        label:
+          - value: unit
+            lang: en
+        description:
+          - value: The unit of measurement associated with a scalar value or the minimum and maximum values.
+            lang: en
+        propertyUri: schema:unit
+        kind: object
+        constraints:
+          - record: Unit
 
 records:
 
@@ -747,6 +794,35 @@ records:
         constraints:
           - record: Concept
 
+  Condition:
+    label:
+      - value: Condition
+        lang: en
+    description:
+      - value: |
+          Used to specify ranges for qualities that act as conditions on the operation of a system.
+
+          A Condition consists of a property (`property`), a value or range of values for that property
+          (value, or minValue and maxValue), and a unit for the values (`unit`).
+        lang: en
+    mixins:
+      - WithValueOrRange
+    classUri: fdri:Condition
+    shortCode: Condition
+    properties:
+      property:
+        label:
+          - value: property
+            lang: en
+        description:
+          - value: |
+              References the definition of the property that measures this condition.
+            lang: en
+        propertyUri: fdri:property
+        kind: object
+        constraints:
+          - record: Variable
+  
   ConfigurationArgument:
     label:
       - value: Data Processing Configuration Argument
@@ -1915,6 +1991,31 @@ records:
         kind: literal
         constraints:
           - datatype: xsd:date
+      hasOperatingRange:
+        label:
+          - value: has operating range
+            lang: en
+        description:
+          - value: |
+              Relation from a `EnvironmentalMonitoringSystem` to an `OperatingRange` describing the normal operating
+              environment of the `EnvironmentalMonitoringSystem`.
+        propertyUri: sys:hasOperatingRange
+        kind: object
+        repeatable: true
+        constraints:
+          - record: OperatingRange
+      hasSurvivalRange:
+        label:
+          - value: has survival range
+            lang: en
+        description:
+          - value: Relation from an `EnvironmentalMonitoringSystem` to a `SurvivalRange`
+            lang: en
+        propertyUri: sys:hasSurvivalRange
+        kind: object
+        repeatable: true
+        constraints:
+          - record: SurvivalRange
       hasSubsystem:
         label:
           - value: has subsystem
@@ -1927,6 +2028,18 @@ records:
         kind: object
         constraints:
           - record: EnvironmentalMonitoringSystem
+      hasSystemCapability:
+        label:
+          - value: has system capability
+            lang: en
+        description:
+          - value: Relation from an `EnvironmentalMonitoringSystem` to a `SystemCapability` describing the capabilities of the `EnvironmentalMonitoringSystem` under certain `Condition`s.
+            lang: en
+        propertyUri: sys:hasSystemCapability
+        kind: object
+        repeatable: true
+        constraints:
+          - record: SystemCapability
       retirementDate:
         label:
           - value: retirement date
@@ -1997,6 +2110,19 @@ records:
     classUri: fdri:EnvironmentalMonitoringSystemType
     shortCode: EnvironmentalMonitoringSystemType
     properties:
+      hasOperatingRange:
+        label:
+          - value: has operating range
+            lang: en
+        description:
+          - value: |
+              Relation from a `EnvironmentalMonitoringSystemType` to an `OperatingRange` describing the normal operating
+              environment of systems of that type.
+        propertyUri: sys:hasOperatingRange
+        kind: object
+        repeatable: true
+        constraints:
+          - record: OperatingRange
       hasProcedure:
         label:
           - value: has procedure
@@ -2009,6 +2135,32 @@ records:
         repeatable: true
         constraints:
           - record: Procedure
+      hasSurvivalRange:
+        label:
+          - value: has survival range
+            lang: en
+        description:
+          - value: Relation from an `EnvironmentalMonitoringSystemType` to a `SurvivalRange`
+            lang: en
+        propertyUri: sys:hasSurvivalRange
+        kind: object
+        repeatable: true
+        constraints:
+          - record: SurvivalRange
+      hasSystemCapability:
+        label:
+          - value: has system capability
+            lang: en
+        description:
+          - value: |
+              Relation from an `EnvironmentalMonitoringSystemType` to a `SystemCapability` describing the capabilities 
+              of the systems of that type under certain `Condition`s.
+            lang: en
+        propertyUri: sys:hasSystemCapability
+        kind: object
+        repeatable: true
+        constraints:
+          - record: SystemCapability
       keyword:
         label:
           - value: keyword
@@ -2545,6 +2697,55 @@ records:
         repeatable: true
         constraints:
           - record: ObservationDataset
+
+  OperatingRange:
+    label:
+      - value: Operating Range
+        lang: en
+    description:
+      - value: |
+          Describes normal operating properties (`hasOperatingProperty`) of an `EnvironmentalMonitoringSystem` 
+          or `EnvironmentalMonitoringSystemType` under some specified `Condition`s (`inCondition`). 
+          
+          For example, the power requirement or maintenance schedule of a system under a specified temperature range.
+
+          In the absence of any `hasOperatingProperty` properties, it simply describes the conditions in which a system
+          is expected to operate.
+          
+          The system continues to operate as defined using `SystemCapability`. 
+          If, however, the `Condition`s are violated, the system is operating 'out of operating range' and 
+          `SystemCapability` specifications may no longer hold.
+    classUri: fdri:OperatingRange
+    shortCode: OperatingRange
+    mixins:
+      - WithValueOrRange
+    properties:
+      hasOperatingProperty:
+        label:
+          - value: has operating property
+            lang: en
+        description:
+          - value: |
+              References the definition of the property that measures this operating range.
+            lang: en
+        propertyUri: sys:hasOperatingProperty
+        kind: object
+        constraints:
+          - record: Variable
+      inCondition:
+        label:
+          - value: in condition
+            lang: en
+        description:
+          - value: |
+              The environmental condition(s) under which this operating range applies.
+            lang: en
+        propertyUri: sys:inCondition
+        kind: object
+        repeatable: true
+        required: true
+        constraints:
+          - record: Condition
 
   PeriodOfTime:
     label:
@@ -3224,6 +3425,123 @@ records:
         constraints:
           - record: RelativeLocation
           - record: Feature
+
+  SurvivalRange:
+    classUri: fdri:SurvivalRange
+    shortCode: SurvivalRange
+    mixins:
+      - WithValueOrRange
+    properties:
+      hasSurvivalProperty:
+        label:
+          - value: has survival property
+            lang: en
+        description:
+          - value: |
+              References the property that this `SurvivalRange` provides a value for.
+
+              Examples might include, "Battery lifetime" or "System lifetime".
+
+              This property is optional. If omitted, the `SurvivalRange` describes the conditions
+              that a system may be exposed to without becoming damaged.
+            lang: en
+        propertyUri: sys:hasSurvivalProperty
+        kind: object
+        constraints:
+          - record: Variable
+      inCondition:
+        label:
+          - value: in condition
+            lang: en
+        description:
+          - value: |
+              The condition(s) under which this `SurvivalRange` applies.
+            lang: en
+        propertyUri: sys:inCondition
+        kind: object
+        required: true
+        repeatable: true
+        constraints:
+          - record: Condition
+
+  SystemCapability:
+    label:
+      - value: System Capability
+        lang: en
+    description:
+      - value: |
+          Describes normal measurement, actuation, sampling properties such as accuracy, range, precision, etc. of a
+          System under some specified Conditions such as a temperature range.
+
+          The capabilities specified here are those that affect the primary purpose of the System, while those in
+          OperatingRange represent the system's normal operating environment, including Conditions that don't affect the
+          Observations or the Actuations of the System.
+        lang: en
+    classUri: sys:SystemCapability
+    shortCode: SystemCapability
+    properties:
+      forProperty:
+        label:
+          - value: for property
+            lang: en
+        description:
+          - value: The variable(s) measured by the system that this system capability applies to.
+            lang: en
+        propertyUri: ssn:forProperty
+        kind: object
+        repeatable: true
+        constraints:
+          - record: Variable
+      hasSystemProperty:
+        label:
+          - value: has system property
+            lang: en
+        description:
+          - value: Relation from a `SystemCapability` of a System to a `SystemProperty` describing the capabilities of the System.
+            lang: en
+        propertyUri: sys:hasSystemProperty
+        kind: object
+        repeatable: true
+        nested: true
+        constraints:
+          - record: SystemProperty
+      inCondition:
+        label:
+          - value: in condition
+            lang: en
+        description:
+          - value: Describes the prevailing environmental Conditions for SystemCapabilites, OperatingRanges and SurvivalRanges.
+            lang: en
+        propertyUri: sys:inCondition
+        kind: object
+        required: true
+        constraints:
+          - record: Condition
+
+  SystemProperty:
+    classUri: fdri:SystemProperty
+    shortCode: SystemProperty
+    mixins:
+      - WithValueOrRange
+    properties:
+      property:
+        label:
+          - value: property
+            lang: en
+        description:
+          - value: |
+              References the definition of the system property.
+            lang: en
+        propertyUri: fdri:property
+        kind: object
+        constraints:
+          - record: Variable
+      unit:
+        propertyUri: schema:unit
+        kind: object
+        required: true
+        constraints:
+          - record: Unit
 
   SystemStatus:
     label:


### PR DESCRIPTION
Addresses #6 

* Add the SOSA/SSN systems module to the OWL imports
* Subclass `ssn-system:Condition` to use `fdri:property` to reference the condition property rather than using the resource type.
* Subclass `ssn-system:Condition`, `ssn-system:SystemProperty`, `ssn-system:OperatingRange` and `ssn-system:SurvivalRange` so that they explicitly use  the schema.org properties for value, value range and unit rather than relying on polymorphic resources.
* Allow `ssn-system:hasSystemCapability`, `ssn-system:hasOperatingRange`, and `ssn-system:hasSurvivalRange` on both `fdri:EnvironmentalMonitoringSystem` and on `fdri:EnvironmentalMonintoringSystemType` to allow capabilities and ranges to be captured at the sensor make/model level.
* Reflect the OWL model in the recordspec schema. The properties that relate an EMSystem or EMSystemType are repeatable but currently not nested in line with most of the rest of the schema.
* Add documenation and a simple example