### PR TITLE
Add fdri:document to capture Procedure documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ RECORDS = \
 	Aggregation \
 	ConfigurationItem \
 	Condition \
+	DigitalDocument \
 	EnvironmentalMonitoringPlatform \
 	EnvironmentalMonitoringSensor \
 	EnvironmentalMonitoringSite \
@@ -105,7 +106,7 @@ build/release/fdri.recordspec.yaml: schema/fdri.recordspec.yaml
 	mkdir -p build/release
 	cp $^ build/release
 
-build/fdri.modelspec.yaml: schema/fdri.recordspec.yaml
+build/fdri.modelspec.yaml: schema/fdri.recordspec.yaml | build
 	$(RUN) model-spec-cmd -m $^ -f recordspec -t spec -o $@
 
 build/release/fdri.modelspec.yaml: build/fdri.modelspec.yaml

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -133,7 +133,8 @@ geo:location rdf:type owl:AnnotationProperty ;
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/certification
 :certification rdf:type owl:ObjectProperty ;
-               rdfs:comment "A link to the document that certifies the system"@en ;
+               rdfs:subPropertyOf :document ;
+               rdfs:comment "A reference to the document that certifies the system"@en ;
                rdfs:label "certification"@en .
 
 
@@ -158,6 +159,13 @@ geo:location rdf:type owl:AnnotationProperty ;
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/contains
 :contains rdf:type owl:ObjectProperty .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/document
+:document rdf:type owl:ObjectProperty ;
+          rdfs:range schema:DigitalDocument ;
+          rdfs:comment "A reference to a document that is related to the enclosing resource."@en ;
+          rdfs:label "document"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/environmentalDomain
@@ -470,6 +478,11 @@ dct:replaces rdf:type owl:ObjectProperty .
 
 ###  http://purl.org/dc/terms/type
 dct:type rdf:type owl:ObjectProperty .
+
+
+###  http://schema.org/associatedMedia
+schema:associatedMedia rdf:type owl:ObjectProperty ;
+                       rdfs:range schema:MediaObject .
 
 
 ###  http://schema.org/unit
@@ -1719,6 +1732,10 @@ It is recommended that every dataset should specify the feature(s) of interest (
                              owl:allValuesFrom :ProcedureType
                            ] ,
                            [ rdf:type owl:Restriction ;
+                             owl:onProperty :document ;
+                             owl:minCardinality "0"^^xsd:nonNegativeInteger
+                           ] ,
+                           [ rdf:type owl:Restriction ;
                              owl:onProperty :procedurePeriodicity ;
                              owl:maxCardinality "1"^^xsd:nonNegativeInteger
                            ] ;
@@ -2130,6 +2147,21 @@ A Time-Series Definition captures the information that is common across multiple
 
 ###  http://qudt.org/schema/qudt/Unit
 <http://qudt.org/schema/qudt/Unit> rdf:type owl:Class .
+
+
+###  http://schema.org/DigitalDocument
+schema:DigitalDocument rdf:type owl:Class ;
+                       rdfs:subClassOf dcat:Resource ,
+                                       [ rdf:type owl:Restriction ;
+                                         owl:onProperty schema:associatedMedia ;
+                                         owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                       ] ;
+                       rdfs:comment "An electronic file or document."@en ;
+                       rdfs:label "Digital Document"@en .
+
+
+###  http://schema.org/MediaObject
+schema:MediaObject rdf:type owl:Class .
 
 
 ###  http://schema.org/PropertyValue

--- a/samples/id/document/certification-123456.jsonld
+++ b/samples/id/document/certification-123456.jsonld
@@ -1,0 +1,12 @@
+{
+  "$schema": "../../schema/DigitalDocument.schema.json",
+  "@context":"../../context/DigitalDocument.context.jsonld",
+  "@id": "http://fdri.ceh.ac.uk/id/doc/certification-123456",
+  "title": [{"@value": "Certification for Sensor 123456", "@language": "en"}],
+  "associatedMedia": [
+    {
+        "contentUrl": {"@id": "http://doc.ceh.ac.uk/some/path/to/the.doc"},
+        "encodingFormat": "application/pdf"
+    }
+  ]
+}

--- a/samples/id/document/cosmos-ta-sampling-regime.jsonld
+++ b/samples/id/document/cosmos-ta-sampling-regime.jsonld
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../schema/DigitalDocument.schema.json",
+  "@context":"../../context/DigitalDocument.context.jsonld",
+  "@id": "http://fdri.ceh.ac.uk/id/doc/cosmos-ta-sampling-regime",
+  "title": [{"@value": "COSMOS Air Temperature Sampling Regime", "@language": "en"}],
+  "associatedMedia": [
+    {
+        "contentUrl": {"@id": "http://doc.ceh.ac.uk/some/path/to/the.doc"},
+        "encodingFormat": "application/pdf"
+    },
+    {
+        "contentUrl": {"@id": "http://doc.ceh.ac.uk/some/path/to/a/webpage"},
+        "encodingFormat": "text/html"
+    }
+  ]
+}

--- a/samples/id/environmental-monitoring-sensor/123456.jsonld
+++ b/samples/id/environmental-monitoring-sensor/123456.jsonld
@@ -18,6 +18,9 @@
     "@value": "2018-05-18",
     "@type": "http://www.w3.org/2001/XMLSchema#date"
   },
+  "certification": {
+    "@id": "http://fdri.ceh.ac.uk/id/document/certification-123456"
+  },
   "calibrationDue": {
     "@value": "2025-12-12",
     "@type": "http://www.w3.org/2001/XMLSchema#date"

--- a/samples/id/procedure/cosmos-sampling-regime-ta.jsonld
+++ b/samples/id/procedure/cosmos-sampling-regime-ta.jsonld
@@ -2,5 +2,6 @@
     "$schema": "../../schema/Procedure.schema.json",
     "@type": "http://fdri.ceh.ac.uk/vocab/metadata/Procedure",
     "type": {"@id": "http://fdri.ceh.ac.uk/ref/common/procedure-type/sampling-regime"},
-    "label": [{"@value": "Sampling regime for COSMOS Air temperature Measurements", "@language": "en"}]
+    "label": [{"@value": "Sampling regime for COSMOS Air temperature Measurements", "@language": "en"}],
+    "document": [{"@id": "http://fdri.ceh.ac.uk/id/document/cosmos-ta-samping-regime"}]
 }

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -1175,143 +1175,6 @@ records:
         constraints:
           - record: ConfigurationParameter
   
-  Deployment:
-    label:
-      - value: Deployment
-        lang: en
-    description:
-      - value: |
-          Describes the deployment of one or more systems of sensors for some purpose.
-          A deployment may be associated with a platform on which the sensors or systems were deployed.
-    classUri: fdri:Deployment
-    shortCode: Deployment
-    mixins:
-      - WithLabelAndComment
-    properties:
-      startedAtTime:
-        label:
-          - value: started at
-            lang: en
-        description:
-          - value: The date and time at which the deployment commenced.
-            lang: en
-        propertyUri: prov:startedAtTime
-        kind: literal
-        constraints:
-          - datatype: xsd:dateTime
-      endedAtTime:
-        label:
-          - value: ended at
-            lang: en
-        description:
-          - value: The date and time at which the deployment is considered to have ended.
-            lang: en
-        propertyUri: prov:endedAtTime
-        kind: literal
-        constraints:
-          - datatype: xsd:dateTime
-      canopyHeight:
-        label:
-          - value: canopy height
-            lang: en
-        description:
-          - value: The observed height of the tree canopy at the deployment site. Reported in metres above ground level.
-            lang: en
-        propertyUri: fdri:canopyHeight
-        kind: literal
-        constraints:
-          - datatype: xsd:decimal
-      deployedOnPlatform:
-        label:
-          - value: deployed on
-            lang: en
-        description:
-          - value: A reference to the entity which hosts the deployed system.
-            lang: en
-        propertyUri: ssn:deployedOnPlatform
-        kind: object
-        constraints:
-          - record: EnvironmentalMonitoringPlatform
-          - record: EnvironmentalMonitoringSite
-      deployedSystem:
-        label:
-          - value: deployed system
-            lang: en
-        description:
-          - value: The sensor or sensor package which was deployed.
-            lang: en
-        propertyUri: ssn:deployedSystem
-        kind: object
-        repeatable: true
-        constraints:
-          - record: EnvironmentalMonitoringSystem
-      implements:
-        label:
-          - value: implements
-            lang: en
-        description:
-          - value: |
-              A procedure which is implemented by this deployment. e.g. sensor sampling regime.
-            lang: en
-        propertyUri: ssn:implements
-        kind: object
-        repeatable: true
-        constraints:
-          - record: Procedure
-      dependencyNote:
-        label:
-          - value: dependency note
-            lang: en
-        description:
-          - value: |
-              A note about a deployment that provides additional information about deployment dependencies.
-            lang: en
-        propertyUri: fdri:dependencyNote
-        kind: literal
-        repeatable: true
-        constraints:
-          - datatype: rdf:langString
-      deploymentNote:
-        label:
-          - value: deployment note
-            lang: en
-        description:
-          - value: |
-              A textual note providing additional information about the enclosing Deployment.
-              This property should be used only if there is not a more specific property to capture the information.
-              More specific properties currently defined are `dependencyNote` and `deploymentVariance`.
-        propertyUri: fdri:deploymentNote
-        kind: literal
-        repeatable: true
-        constraints:
-          - datatype: rdf:langString
-      deploymentVariance:
-        label:
-          - value: deployment variance
-            lang: en
-        description:
-          - value: |
-              A description of any way(s) in which this specific deployment differs from the standard way in which 
-              a deployment of the same kind of system to the same kind of platform would be carried out.
-            lang: en
-        propertyUri: fdri:deploymentVariance
-        kind: literal
-        repeatable: true
-        constraints:
-          - datatype: rdf:langString
-      settleInPeriod:
-        label:
-          - value: settle-in period
-            lang: en
-        description:
-          - value: |
-              The period of time that should be allowed to elapse from the start date of this deployment before
-              the measures that the deployed system make are considered accurate.
-        propertyUri: fdri:settleInPeriod
-        kind: literal
-        constraints:
-          - datatype: xsd:duration
-
   Dataset:
     label:
       - value: Dataset
@@ -1507,7 +1370,171 @@ records:
         repeatable: true
         constraints:
           - record: Concept
-      
+
+  Deployment:
+    label:
+      - value: Deployment
+        lang: en
+    description:
+      - value: |
+          Describes the deployment of one or more systems of sensors for some purpose.
+          A deployment may be associated with a platform on which the sensors or systems were deployed.
+    classUri: fdri:Deployment
+    shortCode: Deployment
+    mixins:
+      - WithLabelAndComment
+    properties:
+      startedAtTime:
+        label:
+          - value: started at
+            lang: en
+        description:
+          - value: The date and time at which the deployment commenced.
+            lang: en
+        propertyUri: prov:startedAtTime
+        kind: literal
+        constraints:
+          - datatype: xsd:dateTime
+      endedAtTime:
+        label:
+          - value: ended at
+            lang: en
+        description:
+          - value: The date and time at which the deployment is considered to have ended.
+            lang: en
+        propertyUri: prov:endedAtTime
+        kind: literal
+        constraints:
+          - datatype: xsd:dateTime
+      canopyHeight:
+        label:
+          - value: canopy height
+            lang: en
+        description:
+          - value: The observed height of the tree canopy at the deployment site. Reported in metres above ground level.
+            lang: en
+        propertyUri: fdri:canopyHeight
+        kind: literal
+        constraints:
+          - datatype: xsd:decimal
+      deployedOnPlatform:
+        label:
+          - value: deployed on
+            lang: en
+        description:
+          - value: A reference to the entity which hosts the deployed system.
+            lang: en
+        propertyUri: ssn:deployedOnPlatform
+        kind: object
+        constraints:
+          - record: EnvironmentalMonitoringPlatform
+          - record: EnvironmentalMonitoringSite
+      deployedSystem:
+        label:
+          - value: deployed system
+            lang: en
+        description:
+          - value: The sensor or sensor package which was deployed.
+            lang: en
+        propertyUri: ssn:deployedSystem
+        kind: object
+        repeatable: true
+        constraints:
+          - record: EnvironmentalMonitoringSystem
+      implements:
+        label:
+          - value: implements
+            lang: en
+        description:
+          - value: |
+              A procedure which is implemented by this deployment. e.g. sensor sampling regime.
+            lang: en
+        propertyUri: ssn:implements
+        kind: object
+        repeatable: true
+        constraints:
+          - record: Procedure
+      dependencyNote:
+        label:
+          - value: dependency note
+            lang: en
+        description:
+          - value: |
+              A note about a deployment that provides additional information about deployment dependencies.
+            lang: en
+        propertyUri: fdri:dependencyNote
+        kind: literal
+        repeatable: true
+        constraints:
+          - datatype: rdf:langString
+      deploymentNote:
+        label:
+          - value: deployment note
+            lang: en
+        description:
+          - value: |
+              A textual note providing additional information about the enclosing Deployment.
+              This property should be used only if there is not a more specific property to capture the information.
+              More specific properties currently defined are `dependencyNote` and `deploymentVariance`.
+        propertyUri: fdri:deploymentNote
+        kind: literal
+        repeatable: true
+        constraints:
+          - datatype: rdf:langString
+      deploymentVariance:
+        label:
+          - value: deployment variance
+            lang: en
+        description:
+          - value: |
+              A description of any way(s) in which this specific deployment differs from the standard way in which 
+              a deployment of the same kind of system to the same kind of platform would be carried out.
+            lang: en
+        propertyUri: fdri:deploymentVariance
+        kind: literal
+        repeatable: true
+        constraints:
+          - datatype: rdf:langString
+      settleInPeriod:
+        label:
+          - value: settle-in period
+            lang: en
+        description:
+          - value: |
+              The period of time that should be allowed to elapse from the start date of this deployment before
+              the measures that the deployed system make are considered accurate.
+        propertyUri: fdri:settleInPeriod
+        kind: literal
+        constraints:
+          - datatype: xsd:duration
+
+  DigitalDocument:
+    label:
+      - value: Digital document
+        lang: en
+    description:
+      - value: An electronic file or document.
+        lang: en
+    classUri: schema:DigitalDocument
+    shortCode: DigitalDocument
+    mixins:
+      - CataloguedResource
+      - WithTitleAndDescription
+      - WithPublicationMetadata
+    properties:
+      associatedMedia:
+        label:
+          - value: encoding
+            lang: en
+        description:
+          - value: A media object that encodes this DigitalDocument.
+            lang: en
+        propertyUri: schema:associatedMedia
+        kind: object
+        repeatable: true
+        nested: true
+        constraints:
+          - record: MediaObject
 
   Distribution:
     label:
@@ -2564,6 +2591,37 @@ records:
     classUri: fdri:MeasureScheme
     shortCode: MeasureScheme
 
+  MediaObject:
+    label:
+      - value: MediaObject
+        lang: en
+    description:
+      - value: A media object, such as an image, video, audio, or text object embedded in a web page or as a separate downloadable resource.
+        lang: en
+    classUri: schema:MediaObject
+    shortCode: MediaObject
+    properties:
+      contentUrl:
+        label:
+          - value: content URL
+            lang: en
+        description:
+          - value: Actual bytes of the media object, for example the image file or video file.
+            lang: en
+        propertyUri: schema:contentUrl
+        kind: object     
+      encodingFormat:
+        label:
+          - value: encoding format
+            lang: en
+        description:
+          - value: Media type typically expressed using a MIME format (see IANA site and MDN reference), e.g. application/zip for a SoftwareApplication binary, audio/mpeg for .mp3 etc.
+            lang: en
+        propertyUri: schema:encodingFormat
+        kind: literal
+        constraints:
+          - datatype: xsd:string
+
   ObservationDataset:
     label:
       - value: Observation Dataset
@@ -2836,6 +2894,18 @@ records:
         kind: object
         constraints:
           - record: ProcedureType
+      document:
+        label:
+          - value: document
+            lang: en
+        description:
+          - value: The documentation that relates to this Procedure.
+            lang: en
+        propertyUri: fdri:document
+        kind: object
+        repeatable: true
+        constraints:
+          - record: MediaObject
   
   ProcedureType:
     label:


### PR DESCRIPTION
* Add schema:DigitalDocument and schema:MediaObject classes to represent a document and a document download respectively
* Make schema:DigitalDocument a subclass of dcat:Resource to capture publication metadata in a manner consistent with datasets
* Add fdri:document with range schema:DigitalDocument
* Make fdri:certification a sub-property of fdri:document
* Add fdri:document a an optional repeatable property of fdri:Procedure
* Fixed alphabetical mis-ordering of the Dataset record definition in the recordspec

NOTE: Only a minimal set of the schema.org properties for schema:DigitalDocument and schema:MediaObject have been added to the recordspec model. Many of the schema:DigitalDocument properties would clash with those provided by dcat:Resource in any case.

Addresses #26