### PR TITLE
Add EMActivity for survey datasets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ RECORDS = \
 	Aggregation \
 	ConfigurationItem \
 	Condition \
+	Dataset \
+	Deployment \
 	DigitalDocument \
+	EnvironmentalMonitoringActivity \
 	EnvironmentalMonitoringPlatform \
 	EnvironmentalMonitoringSensor \
 	EnvironmentalMonitoringSite \
@@ -19,6 +22,7 @@ RECORDS = \
 	GeospatialFeatureOfInterest \
 	InternalDataProcessingConfiguration \
 	Measure \
+	ObservationDataset \
 	OperatingRange \
 	Procedure \
 	StaticDeployment \

--- a/doc/deployments.md
+++ b/doc/deployments.md
@@ -1,8 +1,6 @@
 ## Deployments
 
-Deployments are used when a system (a sensor or package of sensors) is deployed in the field. 
-  * A `MobileDeployment` is a deployment of a system on a platform that moves along a track recorded by a track log.
-  * A `StaticDeployment` is a deployment of a system at a fixed location, optionally at some height above or depth below local ground level. The fixed location may be specified either by its own geometry or relative to the geometry of the platform or site at which it is deployed.
+Deployments are used when a system (a sensor or package of sensors) is deployed in the field.
 
 Deployments are modelled as a sub-class of `prov:Activity` and of `ssn:Deployment`.
 

--- a/doc/em-activities.md
+++ b/doc/em-activities.md
@@ -8,12 +8,14 @@ An `fdri:EnvironmentalMonitoringActivity` has the following properties:
 
   * `dct:type` relates the activity to an `fdri:ActivityType` concept which qualifies the kind of activity (e.g. UAV survey)
   * `sosa:observes` relates the activity to one or more `fdri:Variable`s that are measured during the activity
-  * `fdri:measures` relates the activity to the specific `fdri:Measures` that are used when observing the variables
-  * `fdri:facilityUsage` relates the activity to a `fdri:FacilityUsage` that combines an `fdri:EnvironmentalMonitoringFacility` (via `prov:entity`) used in the activity, and an `fdri:FacilityUsageRole` (via `prov:hadRole`) that indicates the relationship between the activity and the facility (e.g. craft). Any `fdri:EnvironmentalMonitoringFacility` may be used by an activity including sites, platforms, sensor packages and individual sensors.
-  * `prov:qualifiedAssociation` relates the activity to a `prov:Association` which combines:
-    * An optional `fdri:Procedure` followed by any number of `prov:Agent`s in the execution of the activity (via `prov:hadPlan`).
+  * `fdri:measures` relates the activity to the specific `fdri:Measure`s that are used when observing the variables
+  * `fdri:facilityUsage` relates the activity to a `fdri:FacilityUsage` which combines:
+    * an `fdri:EnvironmentalMonitoringFacility` (thus including sites, platforms and individual sensors) used in the activity (via `prov:entity`)
+    * an `fdri:FacilityUsageRole` that indicates the relationship between the activity and the facility (e.g. craft) (via `prov:hadRole`). 
+  * `prov:qualifiedAssociation` relates the activity to an `fdri:RelatedPartyAssociation` which combines:
+    * An optional `fdri:Procedure` followed in the execution of the activity (via `prov:hadPlan`).
     * Any number of `prov:Agent`s involved in the activity (via `prov:agent`)
-    * An optional `skos:Concept` representing the role played by the agents in activity when they executed that procedure.
+    * An optional `fdri:RelatedPartyRole` representing the role played by the agents in activity when they executed that procedure (via `prov:hadRole`).
   * `prov:startedAtTime` and `prov:endedAtTime` properties may be used to capture the start and end timestamps for the activity.
 
 An `fdri:EnvironmentalMonitoringActivity` may be initiated (`fdri:initiated`) by either an `fdri:EnvironmentalMonitoringProgramme` or by another `fdri:EnvironmentalMonitoringActivity`.
@@ -100,12 +102,16 @@ Survey -- fdri:initiated --> Flight2
 
 #### Site of the survey
 
-The site over which the sorties are flown can be modelled as the feature of interest of the activities. In this case the sorties treated as having the same feature of interest as the survey and so the relationship does not need to be repeated.
+The site over which the sorties are flown can be modelled as the feature of interest of the activities.
+In this case the sorties treated as having the same feature of interest as the survey and so the relationship does not need to be repeated.
 
-As the site is an `fdri:GeospatialFeatureOfInterest` it can have geospatial co-ordinates and/or boundaries associated with it to locate the survey in geospatial terms. In this case only the latitude and longitude of a representative point for the survey site is given.
+As the site is an `fdri:GeospatialFeatureOfInterest` it can have geospatial co-ordinates and/or boundaries associated with it to locate the survey in geospatial terms.
+In this case only the latitude and longitude of a representative point for the survey site is given.
 
 > **NOTE:**
-> This is a very simple example of providing geospatial information for an activity. In more detailed modelling it would be possible to use `sosa:hasFeatureOfInterest` to denote the geometry of each individual sortie as well as the bounding geometry of all sorties at the survey level.
+> This is a very simple example of providing geospatial information for an activity.
+> In more detailed modelling it would be possible to use `sosa:hasFeatureOfInterest` to denote the geometry of each individual sortie as well as the bounding geometry of all sorties at the survey level.
+
 ```mermaid
 flowchart
 Survey["Survey
@@ -119,9 +125,10 @@ Survey -- sosa:hasFeatureOfInterest --> Site
 
 #### Platform and Sensor Usage
 
-The drone used in the survey is an `fdri:EnvironmentalMonitoringPlatform` that is used in the role of `PilotedCraft`
+The drone used in the survey is an `fdri:EnvironmentalMonitoringPlatform` and it plays the role of `Piloted Craft`.
 
-There is an `fdri:Deployment` of the sensor to the drone for the duration of the survey. In some cases a sensor or package of sensors may be more permanently affixed to a craft, in which case the time span for the `fdri:Deployment` may be much broader than the time span of any `fdri:EnvironmentalMonitoringActivity` that makes use of the drone.
+There is an `fdri:Deployment` of the sensor to the drone for the duration of the survey.
+In some cases a sensor or package of sensors may be more permanently affixed to a craft, in which case the time span for the `fdri:Deployment` may be much broader than the time span of any `fdri:EnvironmentalMonitoringActivity` that makes use of the drone.
 
 As the same drone is used for the same purpose in each survey, the metadata about the use of the drone can be captured at the survey level.
 
@@ -188,6 +195,9 @@ Piloting -- prov:hadRole --> Pilot
 #### Outputs generated by each sortie
 
 A raw flight log is produced for each sortie. These are the directly generated data files which are then processed in conjunction with the sensor logs to produce the dataset. These files could be modelled as `prov:wasGeneratedBy` each sortie.
+
+> **NOTE**
+> This optional modelling of the outputs of each sortie does not preclude the option of creating full-blown `fdri:ObservationDatasets` from each sortie and relating them to the sortie activity that the data came from.
 
 ```mermaid
 flowchart

--- a/doc/em-activities.md
+++ b/doc/em-activities.md
@@ -1,0 +1,231 @@
+## Environmental Monitoring Activity Model
+
+### Environmental Monitoring Activity
+
+The class `fdri:EnvironmentalMonitoringActivity` represents some activity which is used to gather observations about some feature of interest in the environment.
+
+An `fdri:EnvironmentalMonitoringActivity` has the following properties:
+
+  * `dct:type` relates the activity to an `fdri:ActivityType` concept which qualifies the kind of activity (e.g. UAV survey)
+  * `sosa:observes` relates the activity to one or more `fdri:Variable`s that are measured during the activity
+  * `fdri:measures` relates the activity to the specific `fdri:Measures` that are used when observing the variables
+  * `fdri:facilityUsage` relates the activity to a `fdri:FacilityUsage` that combines an `fdri:EnvironmentalMonitoringFacility` (via `prov:entity`) used in the activity, and an `fdri:FacilityUsageRole` (via `prov:hadRole`) that indicates the relationship between the activity and the facility (e.g. craft). Any `fdri:EnvironmentalMonitoringFacility` may be used by an activity including sites, platforms, sensor packages and individual sensors.
+  * `prov:qualifiedAssociation` relates the activity to a `prov:Association` which combines:
+    * An optional `fdri:Procedure` followed by any number of `prov:Agent`s in the execution of the activity (via `prov:hadPlan`).
+    * Any number of `prov:Agent`s involved in the activity (via `prov:agent`)
+    * An optional `skos:Concept` representing the role played by the agents in activity when they executed that procedure.
+  * `prov:startedAtTime` and `prov:endedAtTime` properties may be used to capture the start and end timestamps for the activity.
+
+An `fdri:EnvironmentalMonitoringActivity` may be initiated (`fdri:initiated`) by either an `fdri:EnvironmentalMonitoringProgramme` or by another `fdri:EnvironmentalMonitoringActivity`.
+
+As `fdri:EnvironmentalMonitoringActivity` is a sub-class of `prov:Activity` it can also be related to entities that it generates or modifies (`prov:wasGeneratedBy`, `fdri:wasModifiedBy`). 
+It is recommended that `prov:wasGeneratedBy` should be used only for those resources which are a direct result of the activity (e.g. a GPS track log for a UAV flight or a raw sensor log file).
+An `fdri:EnvironmentalMonitoringActivity` generates data which contributes to any number of `fdri:ObservationDataset`s.
+The property `fdri:originatingActivity` which should be used to relate an `fdri:ObservationDataset` to the `fdri:EnvironmentalMonitoringActivity` (or activities) which produced the data contained in the dataset.
+
+```mermaid
+---
+config:
+    class:
+        hideEmptyMembersBox: true
+---
+classDiagram
+  direction LR
+class Activity["prov:Activity"] {
+  startedAtTime: xsd:dateTime
+  endedAtTime: xsd:dateTime
+}
+class EMActivity["fdri:EnvironmentalMonitoringActivity"]
+class EMProgramme["fdri:EnvironmentalMonitoringProgramme"]
+class ObservationDataset["fdri:ObservationDataset"]
+class Agent["prov:Agent"]
+class Variable["fdri:Variable"]
+class Measure["fdri:Measure"]
+class Association["fdri:RelatedPartyAssociation"]
+class Concept["skos:Concept"]
+class FacilityUsage["fdri:FacilityUsage"]
+class FoI["fdri:GeospatialFeatureOfInterest"]
+class ActivityType["fdri:ActivityType"]
+class Procedure["fdri:Procedure"]
+class RelatedPartyRole["fdri:RelatedPartyRole"]
+class EMFacility["fdri:EnvironmentalMonitoringFacility"]
+
+Activity <|-- EMActivity
+EMActivity --> EMActivity: fdri_initiated
+EMActivity --> ActivityType: dct_type
+EMProgramme --> EMActivity: fdri_initiated
+ObservationDataset --> EMActivity: fdri_originatingActivity
+EMActivity --> Variable: sosa_observes
+EMActivity --> Measure: fdri_measures
+EMActivity --> FoI: sosa_hasFeatureOfInterest
+EMActivity --> Association: prov_qualifiedAssociation
+Association --> Agent: prov_agent
+Association --> Procedure: prov_hadPlan
+Association --> RelatedPartyRole: prov_hadRole
+EMActivity --> FacilityUsage: fdri_facilityUsage
+FacilityUsage --> EMFacility: prov_used
+FacilityUsage --> FacilityUsageRole: prov_hadRole
+FacilityUsageRole --|> Concept
+RelatedPartyRole --|> Concept
+```
+
+### Example: UAV dataset using Environmental Monitoring Activities
+
+As an example of the use of `fdri:EnvironmentalMonitoringActivity`, take the case of a dataset derived from a survey performed using a drone. The drone is piloted over a site, taking readings of the concentration of nitrogen oxide (NOx) in the atmosphere. The survey consists of multiple individual sorties, and the data from each of the sorties is then combined into a single dataset.
+
+#### Survey and Sorties as nested activities
+
+Both the survey, and each sortie in the survey can be modelled as an `fdri:EnvironmentalMonitoringActivity`. With the sortie activities being intiated by the survey activity, and the survey activity being initiated by the `fdri:EnvironmentalMonitoringProgramme` that the survey is part of.
+
+```mermaid
+flowchart
+Programme["Programme
+&lt;&lt;fdri:EnvironmentalMonitoringProgramme>>"]
+Survey["Survey
+&lt;&lt;fdri:EnvironmentalMonitoringActivity>>
+startedAtTime: 2025-06-21T09:00:00Z
+endedAtTime: 2025-06-21T11:00:00Z"]
+Flight1["Flight 1
+&lt;&lt;fdri:EnvironmentalMonitoringActivity>>
+startedAtTime: 2025-06-21T09:15:00Z
+endedAtTime: 2025-06-21T09:45:00Z"]
+Flight2["Flight 2
+&lt;&lt;fdri:EnvironmentalMonitoringActivity>>
+startedAtTime: 2025-06-21T10:15:00Z
+endedAtTime: 2025-06-21T10:45:00Z"]
+Programme -- fdri:initiated --> Survey
+Survey -- fdri:initiated --> Flight1
+Survey -- fdri:initiated --> Flight2
+```
+
+#### Site of the survey
+
+The site over which the sorties are flown can be modelled as the feature of interest of the activities. In this case the sorties treated as having the same feature of interest as the survey and so the relationship does not need to be repeated.
+
+As the site is an `fdri:GeospatialFeatureOfInterest` it can have geospatial co-ordinates and/or boundaries associated with it to locate the survey in geospatial terms. In this case only the latitude and longitude of a representative point for the survey site is given.
+
+> **NOTE:**
+> This is a very simple example of providing geospatial information for an activity. In more detailed modelling it would be possible to use `sosa:hasFeatureOfInterest` to denote the geometry of each individual sortie as well as the bounding geometry of all sorties at the survey level.
+```mermaid
+flowchart
+Survey["Survey
+&lt;&lt;fdri:EnvironmentalMonitoringActivity>>"]
+Site["SOME_SITE
+&lt;&lt;fdri:GeospatialFeatureOfInterest>>
+geo:lat: 51.48199
+geo:long: -2.76973"]
+Survey -- sosa:hasFeatureOfInterest --> Site
+```
+
+#### Platform and Sensor Usage
+
+The drone used in the survey is an `fdri:EnvironmentalMonitoringPlatform` that is used in the role of `PilotedCraft`
+
+There is an `fdri:Deployment` of the sensor to the drone for the duration of the survey. In some cases a sensor or package of sensors may be more permanently affixed to a craft, in which case the time span for the `fdri:Deployment` may be much broader than the time span of any `fdri:EnvironmentalMonitoringActivity` that makes use of the drone.
+
+As the same drone is used for the same purpose in each survey, the metadata about the use of the drone can be captured at the survey level.
+
+```mermaid
+flowchart
+Survey["Survey
+&lt;&lt;fdri:EnvironmentalMonitoringActivity>>"]
+Drone["Drone 123
+&lt;lt;fdri:EnvironmentalMonitoringPlatform"]
+DroneModel["Some Make/Model"]
+Quadcopter["Quadcopter"]
+Sensor["NOx Sensor #345
+&lt;&lt;EMSensor>>"]
+SensorModel["Some Make / Model"]
+SensorType["NOx Detector"]
+Variable["NOx Concentration
+&lt;&lt;Variable>>"]
+Deployment["NOx Sensor Deployment
+&lt;&lt;Deployment>>
+startedAtTime: 2025-06-21T09:00:00Z
+endedAtTime: 2025-06-21T11:00:00Z"]
+FacilityUsage["Use of Drone 123 in Survey
+&lt;&lt;fdri:FacilityUsage>>"]
+Craft["Piloted Craft
+&lt;&lt;fdri:FacilityUsageRole>>"]
+
+DroneModel -- skos:broader --> Quadcopter
+Drone -- dct:type --> DroneModel
+Sensor -- sosa:observedProperty --> Variable
+Sensor -- dct:type --> SensorModel
+SensorModel -- skos:broader --> SensorType
+Deployment -- ssn:deployedOnPlatform --> Drone
+Deployment -- ssn:deployedSystem --> Sensor
+Survey -- fdri:facilityUsage --> FacilityUsage
+FacilityUsage -- prov:entity --> Drone
+FacilityUsage -- prov:hadRole --> Craft
+```
+
+#### Piloting of the drone
+
+The pilot of the drone is an `fdri:Agent` who follows an `fdri:Procedure` in the execution of each sortie. In this case the procedure used relates to the piloting of the craft on a single sortie and so the relationship is expressed against each of the sortie activities as an `fdri:RelatedPartyAssociation`.
+
+```mermaid
+flowchart
+Flight1["Flight 1
+&lt;&lt;fdri:EnvironmentalMonitoringActivity>>"]
+Flight2["Flight 2
+&lt;&lt;fdri:EnvironmentalMonitoringActivity>>"]
+Piloting["Piloting of Sortie
+&lt;&lt;fdri:RelatedPartyAssociation>>"]
+JohnSmith["John Smith
+&lt;&lt;fdri:Agent>>"]
+Pilot["Pilot
+&lt;&lt;fdri:RelatedPartyRole>>"]
+SortieProcedure["Sortie Procedure
+&lt;&lt;fdri:Procedure>>"]
+Flight1 -- prov:qualifiedAssociation --> Piloting
+Flight2 -- prov:qualifiedAssociation --> Piloting
+Piloting -- prov:agent --> JohnSmith
+Piloting -- prov:hadPlan --> SortieProcedure
+Piloting -- prov:hadRole --> Pilot
+```
+
+#### Outputs generated by each sortie
+
+A raw flight log is produced for each sortie. These are the directly generated data files which are then processed in conjunction with the sensor logs to produce the dataset. These files could be modelled as `prov:wasGeneratedBy` each sortie.
+
+```mermaid
+flowchart
+Flight1["Flight 1
+&lt;&lt;fdri:EnvironmentalMonitoringActivity>>"]
+Flight2["Flight 2
+&lt;&lt;fdri:EnvironmentalMonitoringActivity>>"]
+FlightLog1["Flight Log - Flight 1
+&lt;&lt;Dataset>>"]
+FlightLog1 -- dct:type --> FlightLog
+FlightLog1 -- prov:wasGeneratedBy --> Flight1
+FlightLog2["Flight Log - Flight 1
+&lt;&lt;Dataset>>"]
+FlightLog2 -- dct:type --> FlightLog
+FlightLog2 -- prov:wasGeneratedBy --> Flight2
+
+```
+
+#### Dataset created from the survey
+
+The survey data is compiled into a gridded dataset. The metadata for this dataset uses `fdri:originatingActivity` to reference the survey activity, `fdri:originatingFacility` to reference the drone used in the survey, and `sosa:observes` to reference the variable measured.
+
+```mermaid
+flowchart
+Dataset["UAV Sensor Dataset
+&lt;&lt;GriddedDataset>>"]
+Variable["NOx Concentration
+&lt;&lt;Variable>>"]
+UAV["Drone #123
+&lt;&lt;EnvironmentalMonitoringFacility>>"]
+UAVModel["Some Make/Model"]
+Quadcopter["Quadcopter"]
+Survey["Survey
+&lt;&lt;EnvironmentalMonitoringActivity>>"]
+
+UAVModel -- skos:broader --> Quadcopter
+UAV -- dct:type --> UAVModel
+Dataset -- originatingActivity --> Survey
+Dataset -- originatingFacility --> UAV
+Dataset -- sosa:observedProperty --> Variable
+```

--- a/doc/working_notes/uav-dataset-proposal.md
+++ b/doc/working_notes/uav-dataset-proposal.md
@@ -25,6 +25,7 @@ The majority of sensor and platform related information which is required by use
 flowchart
 Activity[EnvironmentalMonitoringActivity]
 Programme[EnvironmentalMonitoringProgramme]
+Usage[FacilityUsage]
 ObservationDataset-- originatingActivity -->Activity
 Programme-- initiated-->Activity
 Activity-- initiated -->Activity
@@ -32,11 +33,12 @@ Activity-- qualifiedAssociation -->Association
 Association -- agent --> Agent
 Association -- hadPlan --> Procedure
 Association -- hadRole --> Concept
-Activity-- qualifiedUsage -->Usage
+Activity-- facilityUsage -->Usage
 Usage -- entity --> EnvironmentalMonitoringFacility
 Usage -- hadRole --> Concept
 Activity -- type --> ActivityType
 Activity -- observes --> Variable
+Activity -- hasFeatureOfInterest --> GeospatialFeatureOfInterest
 ```
 
 * A UAV is modelled as an `EnvironmentalMonitoringPlatform`

--- a/make_doc.py
+++ b/make_doc.py
@@ -107,6 +107,7 @@ if __name__ == '__main__':
     html += make_section('doc/provenance-and-activity.md')
     html += make_section('doc/variables.md')
     html += make_section('doc/emf.md')
+    html += make_section('doc/em-activities.md')
     html += make_section('doc/deployments.md')
     html += make_section('doc/sensor-system.md')
     html += make_section('doc/sensor-capabilities.md')

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -1977,7 +1977,7 @@ The periodicity (`fdri:procedurePeriodicity`) property SHOULD be used to capture
                                     owl:onProperty skos:inScheme ;
                                     owl:allValuesFrom :RelatedPartyRoleScheme
                                   ] ;
-                  rdfs:comment "A concept that defines the role an `fdri:Agent` may play in relation to some resource."@en ;
+                  rdfs:comment "A concept that defines the role an `fdri:Agent` may play in relation to some resource or activity."@en ;
                   rdfs:label "Related Party Role"@en .
 
 

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -175,6 +175,14 @@ geo:location rdf:type owl:AnnotationProperty ;
                      rdfs:label "environmental domain"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/facilityUsage
+:facilityUsage rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf prov:qualifiedUsage ;
+               rdfs:range :FacilityUsage ;
+               rdfs:comment "Relates the enclosing `prov:Activity` resource to an `fdri:FacilityUsage` qualified association resource that specifies the facility used and the role played by the facility in the activity."@en ;
+               rdfs:label "facility usage"@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/group
 :group rdf:type owl:ObjectProperty ;
        rdfs:range :FacilityGroup ;
@@ -269,6 +277,13 @@ When `fdri:hasValue` is present on an item, this property SHOULD NOT be present 
                 rdfs:label "has value series"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/initiated
+:initiated rdf:type owl:ObjectProperty ;
+           rdfs:range :EnvironmentalMonitoringActivity ;
+           rdfs:comment "An `fdri:EnvironmentalMonitoringActivity` may be initiated by an `fdri:EnvironmentalMonitoringProgramme` or by another `fdri:EnvironmentalMonitoringActivity`."@en ;
+           rdfs:label "initiated"@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/interval
 :interval rdf:type owl:ObjectProperty ;
           rdfs:range dct:PeriodOfTime ;
@@ -350,6 +365,13 @@ When `fdri:hasValue` is present on an item, this property SHOULD NOT be present 
                  rdfs:range dct:PeriodOfTime ;
                  rdfs:comment "The period of time during which an Environmental Monitoring Facility is/was operational."@en ;
                  rdfs:label "operating period"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/originatingActivity
+:originatingActivity rdf:type owl:ObjectProperty ;
+                     rdfs:range :EnvironmentalMonitoringActivity ;
+                     rdfs:comment "The Environmental Monitoring Activities that give rise to the data contained in the enclosing dataset."@en ;
+                     rdfs:label "originating activity"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/originatingFacility
@@ -1098,6 +1120,44 @@ A deployment may be associated with a platform on which the sensors or systems w
                            rdfs:label "Environmental Domain Scheme"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/EnvironmentalMonitoringActivity
+:EnvironmentalMonitoringActivity rdf:type owl:Class ;
+                                 rdfs:subClassOf dcat:Resource ,
+                                                 prov:Activity ,
+                                                 [ rdf:type owl:Restriction ;
+                                                   owl:onProperty prov:qualifiedAssociation ;
+                                                   owl:allValuesFrom :RelatedPartyAssociation
+                                                 ] ,
+                                                 [ rdf:type owl:Restriction ;
+                                                   owl:onProperty sosa:hasFeatureOfInterest ;
+                                                   owl:allValuesFrom :GeospatialFeatureOfInterest
+                                                 ] ,
+                                                 [ rdf:type owl:Restriction ;
+                                                   owl:onProperty sosa:observes ;
+                                                   owl:allValuesFrom :Variable
+                                                 ] ,
+                                                 [ rdf:type owl:Restriction ;
+                                                   owl:onProperty :initiated ;
+                                                   owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                                 ] ,
+                                                 [ rdf:type owl:Restriction ;
+                                                   owl:onProperty :measures ;
+                                                   owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                                 ] ,
+                                                 [ rdf:type owl:Restriction ;
+                                                   owl:onProperty sosa:hasFeatureOfInterest ;
+                                                   owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                                 ] ,
+                                                 [ rdf:type owl:Restriction ;
+                                                   owl:onProperty sosa:observes ;
+                                                   owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                                 ] ;
+                                 rdfs:comment """An Activity which gives rise to a set of observations of some environmental feature of interest. Examples include sorties by UAV, a person counting plastic waste in a gridded area of a beach, or a team of people trapping and measuring the size and weight of fish.
+
+An EnvironmentalMonitoringActivity may follow a documented Procedure, and may involve the completion of one or more sub-activities each with their own Procedures."""@en ;
+                                 rdfs:label "Environmental Monitoring Activity"@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/EnvironmentalMonitoringFacility
 :EnvironmentalMonitoringFacility rdf:type owl:Class ;
                                  rdfs:subClassOf dcat:Resource ,
@@ -1246,6 +1306,10 @@ An Environmental Monitoring Platform may host (`sosa:hosts`) any number of syste
 ###  http://fdri.ceh.ac.uk/vocab/metadata/EnvironmentalMonitoringProgramme
 :EnvironmentalMonitoringProgramme rdf:type owl:Class ;
                                   rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                                    owl:onProperty :initiated ;
+                                                    owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                                  ] ,
+                                                  [ rdf:type owl:Restriction ;
                                                     owl:onProperty :utilises ;
                                                     owl:minCardinality "0"^^xsd:nonNegativeInteger
                                                   ] ;
@@ -1509,6 +1573,39 @@ Membership may be expressed directly using the `fdri:hasMember` property, or ind
                          rdfs:label "Environmental Monitoring Facility Group Type Scheme"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/FacilityUsage
+:FacilityUsage rdf:type owl:Class ;
+               rdfs:subClassOf prov:Usage ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty prov:entity ;
+                                 owl:allValuesFrom :EnvironmentalMonitoringFacility
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty prov:hadRole ;
+                                 owl:allValuesFrom :FacilityUsageRole
+                               ] ;
+               rdfs:comment "Specifies the role played by an `fdri:EnvironmentalMonitoringFacility` in relation to the referencing `fdri:EnvironmentalMonitoringActivity`"@en ;
+               rdfs:label "Facility Usage"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/FacilityUsageRole
+:FacilityUsageRole rdf:type owl:Class ;
+                   rdfs:subClassOf skos:Concept ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty skos:inScheme ;
+                                     owl:allValuesFrom :FacilityUsageRoleScheme
+                                   ] ;
+                   rdfs:comment "A skos:Concept representing the role played by an `fdri:EnvironmentalMonitoringFacility` in an `fdri:FacilityUsage` relation. The role describes the way in which the facility is used by the `fdri:EnvironmentalMonitoringActivity` that encloses the `fdri:FacilityUsage`."@en ;
+                   rdfs:label "Facility Usage Role"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/FacilityUsageRoleScheme
+:FacilityUsageRoleScheme rdf:type owl:Class ;
+                         rdfs:subClassOf skos:ConceptScheme ;
+                         rdfs:comment "A skos:ConceptScheme that manages a controlled list of `fdri:FacilityUsageRole` concepts."@en ;
+                         rdfs:label "Facility Usage Role Scheme"@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/Fault
 :Fault rdf:type owl:Class ;
        rdfs:subClassOf [ rdf:type owl:Restriction ;
@@ -1637,6 +1734,10 @@ A current configuration MAY consist of multiple `fdri:ConfigurationItem` instanc
                                     ] ,
                                     [ rdf:type owl:Restriction ;
                                       owl:onProperty :measure ;
+                                      owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :originatingActivity ;
                                       owl:minCardinality "0"^^xsd:nonNegativeInteger
                                     ] ,
                                     [ rdf:type owl:Restriction ;
@@ -1833,6 +1934,25 @@ The periodicity (`fdri:procedurePeriodicity`) property SHOULD be used to capture
               rdfs:subClassOf skos:ConceptScheme ;
               rdfs:comment "A controlled vocabulary of Regions."@en ;
               rdfs:label "Region Scheme"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/RelatedPartyAssociation
+:RelatedPartyAssociation rdf:type owl:Class ;
+                         rdfs:subClassOf prov:Association ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty prov:agent ;
+                                           owl:allValuesFrom :Agent
+                                         ] ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty prov:hadPlan ;
+                                           owl:allValuesFrom :Procedure
+                                         ] ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty prov:hadRole ;
+                                           owl:allValuesFrom :RelatedPartyRole
+                                         ] ;
+                         rdfs:comment "An association between an Agent, the role that they play, and the procedure they followed, in relation to the referencing activity."@en ;
+                         rdfs:label "Related Party Association"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/RelatedPartyAttribution

--- a/samples/id/activity/drone-flight-1.jsonld
+++ b/samples/id/activity/drone-flight-1.jsonld
@@ -1,0 +1,21 @@
+{
+    "$schema": "../../schema/EnvironmentalMonitoringActivity.schema.json",
+    "@id": "http://fdri.ceh.ac.uk/id/activity/drone-flight-1.jsonld",
+    "@type": "http://fdri.ceh.ac.uk/vocab/metadata/EnvironmentalMonitoringActivity",
+    "type": {
+        "@id": "http://fdri.ceh.ac.uk/ref/common/activity-type/sortie"
+    },
+    "qualifiedAssociation": [
+        {
+            "entity": {
+                "@id": "http://fdri.ceh.ac.uk/id/agent/js"
+            },
+            "hadRole": {
+                "@id": "http://fdri.ceh.ac.uk/ref/common/related-party-role/pilot"
+            },
+            "hadPlan": {
+                "@id": "http://fdri.ceh.ac.uk/id/procedure/drone-sortie-procedure"
+            }
+        }
+    ]
+}

--- a/samples/id/activity/drone-survey.jsonld
+++ b/samples/id/activity/drone-survey.jsonld
@@ -1,0 +1,35 @@
+{
+    "$schema": "../../schema/EnvironmentalMonitoringActivity.schema.json",
+    "@id": "http://fdri.ceh.ac.uk/samples/id/activity/drone-survey",
+    "@type": "http://fdri.ceh.ac.uk/vocab/metadata/EnvironmentalMonitoringActivity",
+    "type": {
+        "@id": "http://fdri.ceh.ac.uk/ref/common/activity-type/drone-survey"
+    },
+    "label": [{"@value": "Example Drone Survey Activity", "@language": "en"}],
+    "initiated": [
+        {"@id": "http://fdri.ceh.ac.uk/samples/id/activity/drone-flight-1"},
+        {"@id": "http://fdri.ceh.ac.uk/samples/id/activity/drone-flight-2"}
+    ],
+    "hasFeatureOfInterest": {
+        "@id": "http://fdri.ceh.ac.uk/id/feature-of-interest/bunny"
+    },
+    "startedAtTime": {
+        "@value": "2025-06-21T09:00:00.000Z",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "endedAtTime":{
+        "@value": "2025-06-21T11:00:00.000Z",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+    },
+    "facilityUsage": [
+        {
+            "entity": {
+                "@id": "http://fdri.ceh.ac.uk/id/facility/drone-123"
+            },
+            "hadRole": {
+                "@id": "http://fdri.ceh.ac.uk/ref/common/facility-usage-role/piloted-craft"
+            }
+        }
+    ]
+
+}

--- a/samples/id/dataset/drone-sensor-dataset.jsonld
+++ b/samples/id/dataset/drone-sensor-dataset.jsonld
@@ -1,0 +1,30 @@
+{
+    "$schema": "../../schema/ObservationDataset.schema.json",
+    "@id": "http://fdri.ceh.ac.uk/samples/id/dataset/drone-sensor-dataset.jsonld",
+    "@type": "http://fdri.ceh.ac.uk/vocab/metadata/ObservationDataset",
+    "processingLevel": {
+        "@id": "http://fdri.ceh.ac.uk/ref/common/processing-level/raw"
+    },
+    "observedProperty": [
+        {"@id": "http://fdri.ceh.ac.uk/ref/common/variable/nox-concentration"}
+    ],
+    "originatingActivity": [
+        {"@id": "http://fdri.ceh.ac.uk/id/activity/drone-survey.jsonld"}
+    ],
+    "originatingFacility": [
+        {"@id": "http://fdri.ceh.ac.uk/samples/id/facility/drone-123.jsonld"}
+    ],
+    "hasFeatureOfInterest": [
+        {"@id": "http://fdri.ceh.ac.uk/id/feature-of-interest/bunny"}
+    ],
+    "temporal": {
+        "startDate": {
+            "@value": "2025-06-21T09:15:00.000Z",
+            "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "endDate":{
+            "@value": "2025-06-21T10:45:00.000Z",
+            "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        }
+    }
+}

--- a/samples/id/dataset/flight-1-log.jsonld
+++ b/samples/id/dataset/flight-1-log.jsonld
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../schema/Dataset.schema.json",
+    "@id": "http://fdri.ceh.ac.uk/id/dataset/flight-1-log",
+    "@type": "http://www.w3.org/ns/dcat#Dataset",
+    "type": [{"@id": "http://fdri.ceh.ac.uk/ref/common/dataset-type/flight-log"}]
+
+}

--- a/samples/id/deployment/nox-drone-deployment.jsonld
+++ b/samples/id/deployment/nox-drone-deployment.jsonld
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../schema/Deployment.schema.json",
+    "@id": "http://fdri.ceh.ac.uk/samples/id/deployment/nox-drone-deployment.jsonld",
+    "@type": "http://fdri.ceh.ac.uk/vocab/metadata/Deployment",
+    "deployedSystem": [{"@id": "http://fdri.ceh.ac.uk/id/environmental-monitoring-sensor/nox-1234"}],
+    "deployedOnPlatform": {"@id": "http://fdri.ceh.ac.uk/id/facility/drone-123" }
+}

--- a/samples/id/environmental-monitoring-sensor/nox-1234.jsonld
+++ b/samples/id/environmental-monitoring-sensor/nox-1234.jsonld
@@ -1,0 +1,9 @@
+{
+    "$schema": "../../schema/EnvironmentalMonitoringSensor.schema.json",
+    "@id": "http://fdri.ceh.ac.uk/id/environmental-monitoring-sensor/nox-1234",
+    "@type": "http://fdri.ceh.ac.uk/vocab/metadata/EnvironmentalMonitoringSensor",
+    "type": {"@id": "http://fdri.ceh.ac.uk/ref/common/sensor-type/nox"},
+    "observes": [
+        {"@id": "http://fdri.ceh.ac.uk/ref/common/variable/nox-concentration"}
+    ]
+}

--- a/samples/id/facility/drone-123.jsonld
+++ b/samples/id/facility/drone-123.jsonld
@@ -1,0 +1,10 @@
+{
+    "$schema": "../../schema/EnvironmentalMonitoringPlatform.schema.json",
+    "@id": "http://fdri.ceh.ac.uk/samples/id/facility/drone-123.jsonld",
+    "@type": "http://fdri.ceh.ac.uk/vocab/metadata/EnvironmentalMonitoringPlatform",
+    "type": {
+        "@id": "http://fdri.ceh.ac.uk/ref/common/platform-type/octo-quad"
+    },
+    "isMobile": true,
+    "identifier": ["Drone-123"]
+}

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -478,6 +478,21 @@ records:
         repeatable: true
         constraints:
           - record: QualifiedAssociation
+      qualifiedUsage:
+        label:
+          - value: qualified usage
+            lang: en
+        description:
+          - value: |
+              A qualified usage is a usage of an entity in the context of an activity, where the usage is qualified by
+              entity used and the role that the entity played in relation to the activity.
+            lang: en
+        propertyUri: prov:qualifiedUsage
+        kind: object
+        nested: true
+        repeatable: true
+        constraints:
+          - record: QualifiedUsage
       startedAtTime:
         label:
           - value: started at
@@ -1622,6 +1637,97 @@ records:
     classUri: fdri:EnvironmentalDomainScheme
     shortCode: EnvironmentalDomainScheme
 
+  EnvironmentalMonitoringActivity:
+    label:
+      - value: Environmental Monitoring Activity
+        lang: en
+    description:
+      - value: |
+          An activity that is part of an Environmental Monitoring Programme.
+          An Environmental Monitoring Activity is a sub-type of prov:Activity allowing it to be associated with
+          an Environmental Monitoring Facility via the prov:qualifiedAssociation property.
+    classUri: fdri:EnvironmentalMonitoringActivity
+    shortCode: EnvironmentalMonitoringActivity
+    extends: Activity
+    mixins:
+      - WithLabelAndComment
+      - WithAnnotations
+      - CataloguedResource
+    properties:
+      facilityUsage:
+        label:
+          - value: facility usage
+            lang: en
+        description:
+          - value: |
+              A reference to the Environmental Monitoring Facility or Facilities that are used by this activity,
+              each reference may be qualified by the role that the facility played in the activity.
+            lang: en
+        propertyUri: fdri:facilityUsage
+        kind: object
+        nested: true
+        repeatable: true
+        constraints:
+          - record: FacilityUsage
+      hasFeatureOfInterest:
+        label:
+          - value: has feature of interest
+            lang: en
+        description:
+          - value: The geo-spatial location which is directly observed by the activity.
+            lang: en
+        propertyUri: sosa:hasFeatureOfInterest
+        kind: object
+        constraints:
+          - record: GeospatialFeatureOfInterest
+      initiated:
+        label:
+          - value: initiated
+            lang: en
+        description:
+          - value: The sub-activity or activities that were initiated by this activity.
+        propertyUri: fdri:initiated
+        kind: object
+        repeatable: true
+        constraints:
+          - record: EnvironmentalMonitoringActivity
+      observes:
+        label:
+          - value: observes
+            lang: en
+        description:
+          - value: |
+              The observable property or properties monitored by the activity.
+        propertyUri: sosa:observes
+        kind: object
+        repeatable: true
+        constraints:
+          - record: Variable
+      qualifiedAssociation:
+        label:
+          - value: related party attribution
+            lang: en
+        description:
+          - value: Relates the activity to the agent(s), the role(s) played by those agents, and the procedure that they follow, in the performance of the activity.
+            lang: en 
+        propertyUri: prov:qualifiedAssociation
+        kind: object
+        repeatable: true
+        nested: true
+        constraints:
+          - record: RelatedPartyAssociation
+      type:
+        label:
+          - value: activity type
+            lang: en
+        description:
+          - value: The kind of activity that this Environmental Monitoring Activity represents.
+            lang: en
+        propertyUri: dct:type
+        kind: object
+        constraints:
+          - record: ActivityType
+
   EnvironmentalMonitoringFacility:
     label:
       - value: Environmental Monitoring Faciltiy
@@ -1876,6 +1982,18 @@ records:
       - WithAnnotations
       - WithLabelAndComment
     properties:
+      initiated:
+        label:
+          - value: initiated
+            lang: en
+        description:
+          - value: An Environmental Monitoring Programme may have initiated some Environmental Monitoring Activities.
+            lang: en
+        propertyUri: fdri:initiated
+        kind: object
+        repeatable: true
+        constraints:
+          - record: EnvironmentalMonitoringActivity
       utilises:
         label:
           - value: utilises
@@ -2411,6 +2529,70 @@ records:
     classUri: fdri:FacilityGroupTypeScheme
     shortCode: FacilityGroupTypeScheme
 
+  FacilityUsage:
+    label:
+      - value: Facility Usage
+        lang: en
+    description:
+      - value: |
+          A reference to an Environmental Monitoring Facility or Facilities that are used by an Environmental Monitoring Activity, qualified by the role that the facility played in the activity.
+        lang: en
+    classUri: fdri:FacilityUsage
+    shortCode: FacilityUsage
+    mixins:
+      - WithLabelAndComment
+    properties:
+      entity:
+        label:
+          - value: entity
+            lang: en
+        description:
+          - value: The Environmental Monitoring Facility or Facilities that were used by the activity.
+            lang: en
+        propertyUri: prov:entity
+        kind: object
+        constraints:
+          - record: EnvironmentalMonitoringFacility
+      hadRole:
+        label:
+          - value: had role
+            lang: en
+        description:
+          - value: The role that the facility played in the activity.
+            lang: en
+        propertyUri: prov:hadRole
+        kind: object
+        constraints:
+          - record: FacilityUsageRole
+
+  FacilityUsageRole:
+    label:
+      - value: Facility Usage Role
+        lang: en
+    description:
+      - value: A concept that describes the role that an Environmental Monitoring Facility played in an Environmental Monitoring Activity.
+        lang: en
+    extends: Concept
+    classUri: fdri:FacilityUsageRole
+    shortCode: FacilityUsageRole
+    properties:
+      inScheme:
+        propertyUri: skos:inScheme
+        kind: object
+        constraints:
+          - record: FacilityUsageRoleScheme
+
+  FacilityUsageRoleScheme:
+    label:
+      - value: Facility Usage Role Concept Scheme
+        lang: en
+    description:
+      - value: A controlled vocabulary of facility usage roles.
+        lang: en
+    extends: ConceptScheme
+    classUri: fdri:FacilityUsageRoleScheme
+    shortCode: FacilityUsageRoleScheme
+
   Fault:
     label:
       - value: Fault
@@ -2684,6 +2866,18 @@ records:
         repeatable: true
         constraints:
           - record: EnvironmentalMonitoringFacility
+      originatingActivity:
+        label:
+          - value: originating activity
+            lang: en
+        description:
+          - value: The environmental monitoring activity that resulted in the production of this dataset.
+            lang: en
+        propertyUri: fdri:originatingActivity
+        kind: object
+        repeatable: true
+        constraints:
+          - record: EnvironmentalMonitoringActivity
       originatingSite:
         label:
           - value: originating site
@@ -3207,7 +3401,7 @@ records:
     label:
       - value: A relationship between an Agent, the role that it plaed and the plan that it followed in the execution of some activity.
         lang: en
-    classUri: prov:QualifiedAssociation
+    classUri: prov:Association
     shortCode: QualifiedAssociation
     properties:
       agent:
@@ -3233,6 +3427,37 @@ records:
         repeatable: true
         constraints:
           - record: Plan
+      hadRole:
+        label:
+          - value: had role
+            lang: en
+        description:
+          - value: The role played by the agent in the execution of the activity.
+            lang: en
+        propertyUri: prov:hadRole
+        kind: object
+        constraints:
+          - record: Concept
+
+  QualifiedUsage:
+    label:
+      - value: Qualified Usage
+        lang: en
+    description:
+      - value: A relationship between an entity and the role that it played in the execution of some activity.
+        lang: en
+    classUri: prov:Usage
+    shortCode: QualifiedUsage
+    properties:
+      entity:
+        label:
+          - value: entity
+            lang: en
+        description:
+          - value: The entity involved in the activity
+            lang: en
+        propertyUri: prov:entity
+        kind: object
       hadRole:
         label:
           - value: had role
@@ -3292,6 +3517,53 @@ records:
     extends: ConceptScheme
     classUri: fdri:RegionScheme
     shortCode: RegionScheme
+
+  RelatedPartyAssociation:
+    label:
+      - value: Related Party Association
+        lang: en
+    description:
+      - value: An association between an Agent, the role that they play, and the procedure that they follow, in relation to some `prov:Activity`.
+        lang: en
+    classUri: fdri:RelatedPartyAssociation
+    shortCode: RelatedPartyAssociation
+    properties:
+      hasRole:
+        label:
+          - value: has role
+            lang: en
+        description:
+          - value: The role played by the agent in this association.
+            lang: en
+        propertyUri: dcat:hasRole
+        kind: object
+        required: true
+        constraints:
+          - record: RelatedPartyRole
+      agent:
+        label:
+          - value: agent
+            lang: en
+        description:
+          - value: The agent involved in this association.
+            lang: en
+        propertyUri: prov:Agent
+        kind: object
+        required: true
+        constraints:
+          - record: Agent
+      hadPlan:
+        label:
+          - value: had plan
+            lang: en
+        description:
+          - value: A plan that informed the behaviour of the agent during the execution of the activity.
+            lang: en
+        propertyUri: prov:hadPlan
+        kind: object
+        repeatable: true
+        constraints:
+          - record: Plan
 
   RelatedPartyAttribution:
     label:


### PR DESCRIPTION
* Add fdri:EnvironmentalMonitoringActivity class to represent survey activities and their sub-activities
* Add fdri:FacilityUsage as a subclass of prov:Usage to provide a constrained way to express the use of facilities within an activity
* Add fdri:RelatedPartyAssociation as a subclass of prov:Association to provide a constrained way to express the agent's participating in an EnvironmentalMonitoringActivity, the role they play and the procedure they follow.
* Add fdri:originatingActivity to relate an fdri:ObservationDataset to the fdri:EnvironmentalMonitoringActivity (or activities) that were used to generate the data for the dataset.
* 