### PR TITLE
Add FOAF ontology and use foaf:member

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,12 @@ DRAFT 0.5
   * Add `fdri:FacilityUsage` class as a subclass of `prov:Usage` to represent the use of some EnvironmentalMonitoringFacility in some EnvironmenalMonitoringActivity, qualified by the role (fdri:FacilityUsageRole) that the facility played in the activity.
   * Add `fdri:originatingActivity` to relate an `fdri:ObservationDataset` to the `fdri:EnvironmenalMonitoringActivity` that originated the data contained in the dataset.
   * Add `fdri:RelatedPartyAssociation` to represent the association between an `fdri:Agent` and the role that the played in some `prov:Activity`
+* NEW: Add FOAF ontology as an import for the FDRI ontology
+  * Map fdri:Agent as a subclass of foaf:Agent and prov:Agent
+  * Map fdri:Organization as a subclass of prov:Agent, foaf:Organization, and foaf:Group
+  * Map fdri:Person as a subclass of foaf:Person
+* Add subclasses of fdri:Agent to the recordspec schema
+  * Added fdri:Organization, fdri:Person and fdri:SoftwareAgent to the recordspec schema
 
 DRAFT 0.4.2
 -----------

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -24,6 +24,7 @@
                                                     <http://www.w3.org/ns/dcat3> ,
                                                     ssn:ext ,
                                                     <http://www.w3.org/ns/ssn/systems/> ,
+                                                    <http://xmlns.com/foaf/0.1/> ,
                                                     <https://w3id.org/iadopt/ont/1.0.3> ;
                                         rdfs:comment "An ontology for the recording of dataset metadata, provenance information and related reference data for use in the fine-grained metadata store element of the FDRI project."@en ;
                                         rdfs:label "FDRI Fine-grained Metadata Store Ontology"@en ;
@@ -824,7 +825,8 @@ geo:long rdf:type owl:DatatypeProperty ;
 ###  http://fdri.ceh.ac.uk/vocab/metadata/Agent
 :Agent rdf:type owl:Class ;
        rdfs:subClassOf dcat:Resource ,
-                       prov:Agent ;
+                       prov:Agent ,
+                       <http://xmlns.com/foaf/0.1/Agent> ;
        rdfs:comment "An Agent is something that has responsibility for an activity that takes place, for the existence or modification of some resource, or for the activity of another Agent."@en ;
        rdfs:label "Agent"@en .
 
@@ -1812,14 +1814,17 @@ It is recommended that every dataset should specify the feature(s) of interest (
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/Organization
 :Organization rdf:type owl:Class ;
-              rdfs:subClassOf :Agent ;
+              rdfs:subClassOf :Agent ,
+                              <http://xmlns.com/foaf/0.1/Group> ,
+                              <http://xmlns.com/foaf/0.1/Organization> ;
               rdfs:comment "A social or legal institution such as a company, society etc."@en ;
               rdfs:label "Organization"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/Person
 :Person rdf:type owl:Class ;
-        rdfs:subClassOf :Agent ;
+        rdfs:subClassOf :Agent ,
+                        <http://xmlns.com/foaf/0.1/Person> ;
         rdfs:comment "A natural person."@en ;
         rdfs:label "Person"@en .
 

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -4,6 +4,8 @@ prefixes:
     uri: http://www.w3.org/ns/dcat#
   - prefix: dct
     uri: http://purl.org/dc/terms/
+  - prefix: foaf
+    uri: http://xmlns.com/foaf/0.1/
   - prefix: fdri
     uri: http://fdri.ceh.ac.uk/vocab/metadata/
   - prefix: geo
@@ -3000,6 +3002,27 @@ records:
         constraints:
           - record: Condition
 
+  Organization:
+    label:
+      - value: Organization
+        lang: en
+    classUri: fdri:Organization
+    shortCode: Organization
+    extends: Agent
+    properties:
+      member:
+        label:
+          - value: member
+            lang: en
+        description:
+          - value: An agent who is a member of the organization.
+            lang: en
+        propertyUri: foaf:member
+        kind: object
+        repeatable: true
+        constraints:
+          - record: Agent
+
   PeriodOfTime:
     label:
       - value: Period Of Time
@@ -3037,7 +3060,15 @@ records:
         constraints:
           - datatype: xsd:date
           - datatype: xsd:dateTime
-  
+
+  Person:
+    label:
+      - value: Person
+        lang: en
+    classUri: fdri:Person
+    shortCode: Person
+    extends: Agent
+
   Plan:
     label:
       - value: Plan
@@ -3678,6 +3709,50 @@ records:
         kind: literal
         constraints:
           - datatype: xsd:decimal
+
+  SoftwareAgent:
+    label:
+      - value: Software Agent
+        lang: en
+    classUri: fdri:SoftwareAgent
+    shortCode: SoftwareAgent
+    extends: Agent
+    properties:
+      repository:
+        label:
+          - value: repository
+            lang: en
+        description:
+          - value: A URL reference to the source control repository where the software agent source code is stored.
+            lang: en
+        propertyUri: fdri:repository
+        kind: literal
+        required: true
+        constraints:
+          - datatype: xsd:anyURI
+      repositoryPath:
+        label:
+          - value: repository path
+            lang: en
+        description:
+          - value: A repository-relative path to the files or directories that contain the software agent source code.
+        propertyUri: fdri:repositoryPath
+        kind: literal
+        repeatable: true
+        constraints:
+          - datatype: xsd:string
+      version:
+        label:
+          - value: version
+            lang: en
+        description:
+          - value: |
+              A version identifier string that specifies the specific version of source code used by the software agent.
+              Where possible the version specified here SHOULD be a source repository version label such as a Git commit hash or tag reference.
+        propertyUri: dct:version
+        kind: literal
+        constraints:
+          - datatype: xsd:string
 
   SoilType:
     label:


### PR DESCRIPTION
* Add import of FOAF ontology
* Map FDRI classes to FOAF ontology as subclasses
* Add subclasses of fdri:Agent to recordspec schema

Addresses #42 and opts for the use of the FOAF vocabulary over the W3C Org vocabulary. As the latter builds on the former and declares subclass/sameAs relations to it the door is still open to importing the full W3C Org vocabulary at a later date should we need to make use of the additional elements it defines.