### PR TITLE
Add model for gridded dataset metadata

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,11 @@ DRAFT 0.5
 * Add subclasses of fdri:Agent to the recordspec schema
   * Added fdri:Organization, fdri:Person and fdri:SoftwareAgent to the recordspec schema
 * Add dct:identifier as a property allowed on fdri:Agent
+* NEW: Add types to support gridded datasets
+  * Add `fdri:GriddedDataset` for the top level dataset.
+  * Add `fdri:GriddedContainer`, `fdri:Array` and `fdri:Dimension` to represent groups, arrays and dimensions with their metadata
+  * Use `fdri:contains` with type restrictions to create nesting relations between gridded datasets, groups, arrays and dimensions.
+  * Add `fdri:references` to express the relation between Arrays and the dimensions(s) they use.
 
 DRAFT 0.4.2
 -----------

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ DRAFT 0.5
   * Add `fdri:GriddedContainer`, `fdri:Array` and `fdri:Dimension` to represent groups, arrays and dimensions with their metadata
   * Use `fdri:contains` with type restrictions to create nesting relations between gridded datasets, groups, arrays and dimensions.
   * Add `fdri:references` to express the relation between Arrays and the dimensions(s) they use.
+* NON-BREAKING: Relax the definition of rdfs:label in the recordspec schema to allow both xsd:string and rdf:langString literals (was only rdf:langString).
 
 DRAFT 0.4.2
 -----------

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ DRAFT 0.5
   * Use `fdri:contains` with type restrictions to create nesting relations between gridded datasets, groups, arrays and dimensions.
   * Add `fdri:references` to express the relation between Arrays and the dimensions(s) they use.
 * NON-BREAKING: Relax the definition of rdfs:label in the recordspec schema to allow both xsd:string and rdf:langString literals (was only rdf:langString).
+* NON-BREAKING: Add keyword (dcat:keyword) as an optional property of Dataset in the recordspec schema.
 
 DRAFT 0.4.2
 -----------

--- a/doc/gridded-data.md
+++ b/doc/gridded-data.md
@@ -1,0 +1,56 @@
+## Gridded Dataset Model
+
+An `fdri:GriddedDataset` is an [`fdri:ObservationDataset`](time-series-dataset.md) which is distributed as multi-dimensional array data.
+Formats that use this approach include netCDF and ZARR. In addition to all of the standard metadata of an `fdri:ObservationDataset`,
+an `fdri:GriddedDataset` includes metadata about the structure of the multi-dimensional data.
+
+### Gridded Dataset Structure
+
+An `fdri:GriddedDataset` contains:
+  * zero or more `fdri:GriddedContainer`s
+  * zero or more `fdri:Dimension`s,
+  * zero or more `fdri:Array`s, and
+
+An `fdri:GriddedContainer` is a nested structure which may itself contain `fdri:Dimensions`, `fdri:Arrays` and other `fdri:GriddedContainer`s.
+
+An `fdri:Dimension` can be used to provide a common definition of the extent of a dimension which is shared by many `fdri:Arrays`. The size of the dimension can be specified as an integer value using the `fdri:size` property.
+
+An `fdri:Array` represents one multi-dimensional array in the dataset. The property `fdri:shape` can be used to define the shape of an array as an RDF list of integer values giving the size of each dimension of the array. The property `fdri:references` can be used to reference the `fdri:Dimension`s and/or `fdri:Array`s that define each of the dimensions of this array.
+
+An `fdri:Array`, `fdri:Dimension` or `fdri:GriddedContainer` may reference the `fdri:Variable`(s) it provides values for using the `sosa:observedProperty` property, or the `fdri:Measure`(s) it provides values for using the `fdri:measure`. 
+All of these types also allow annotations to be referenced using `fdri:hasAnnotation`. Annotations are the recommended way to capture additional metadata that may be encoded in the dataset such as unit of meaure, coordinates, methods used etc.
+
+```mermaid
+---
+config:
+    class:
+        hideEmptyMembersBox: true
+---
+classDiagram
+class ObservationDataset["fdri:ObservationDataset"]
+class GriddedDataset["fdri:GriddedDataset"]
+class GriddedContainer["fdri:GriddedContainer"]
+class GriddedDatasetResource["fdri:GriddedDatasetResource"]
+class Dimension["fdri:Dimension"] {
+  fdri:size: xsd:integer
+}
+class Array["fdri:Array"] {
+  fdri:shape: List&lt;xsd:integer&gt;
+}
+class Annotation["fdri:Annotation"]
+class Variable["fdri:Variable"]
+class Measure["fdri:Measure"]
+
+ObservationDataset <|-- GriddedDataset
+GriddedDatasetResource <|-- GriddedContainer
+GriddedDatasetResource <|-- Dimension
+GriddedDatasetResource <|-- Array
+
+Array --> Dimension: fdri_references
+Array --> Array: fdri_references
+GriddedDataset --> GriddedDatasetResource: fdri_contains
+GriddedContainer --> GriddedDatasetResource: fdri_contains
+GriddedDatasetResource --> Annotation: fdri_hasAnnotation
+GriddedDatasetResource --> Variable: sosa_observedProperty
+GriddedDatasetResource --> Measure: fdri_measure
+```

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -44,7 +44,6 @@ above the local reference ellipsoid).""" ;
 
 ###  http://www.w3.org/2003/01/geo/wgs84_pos#location
 geo:location rdf:type owl:AnnotationProperty ;
-             rdfs:subPropertyOf <http://xmlns.com/foaf/0.1/based_near> ;
              rdfs:range geo:SpatialThing .
 
 
@@ -428,6 +427,13 @@ When `fdri:hasValue` is present on an item, this property SHOULD NOT be present 
            rdfs:label "qualifier"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/references
+:references rdf:type owl:ObjectProperty ;
+            rdfs:domain :Array ;
+            rdfs:range :GriddedDatasetResource ;
+            rdfs:comment "An Array may reference one or more other gridded dataset resources (other arrays or dimensions)."@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/regionScheme
 :regionScheme rdf:type owl:ObjectProperty ;
               rdfs:subPropertyOf dcat:themeTaxonomy ;
@@ -518,7 +524,8 @@ schema:valueReference rdf:type owl:ObjectProperty .
 
 
 ###  http://www.w3.org/2003/01/geo/wgs84_pos#location
-geo:location rdf:type owl:ObjectProperty .
+geo:location rdf:type owl:ObjectProperty ;
+             rdfs:subPropertyOf <http://xmlns.com/foaf/0.1/based_near> .
 
 
 ###  http://www.w3.org/ns/prov#wasInfluencedBy
@@ -646,6 +653,18 @@ More specific sub-properties `fdri:dependencyNote` and `fdri:deploymentVariance`
            rdfs:label "elevation"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/hasShape
+:hasShape rdf:type owl:DatatypeProperty ;
+          rdfs:comment "A property specifying the shape of a multidimensional array as a list of the integer size of each dimension of the array."@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/isCoordinate
+:isCoordinate rdf:type owl:DatatypeProperty ;
+              rdfs:domain :Array ;
+              rdfs:range xsd:boolean ;
+              rdfs:comment "Indicates if the containing `fdri:Array` is a co-ordinate variable, having a single dimension of the same name in the containing netCDF file."@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/isMobile
 :isMobile rdf:type owl:DatatypeProperty ;
           rdfs:range xsd:boolean ;
@@ -728,11 +747,22 @@ More specific sub-properties `fdri:dependencyNote` and `fdri:deploymentVariance`
                 rdfs:label "settle-in period"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/shape
+:shape rdf:type owl:DatatypeProperty ;
+       rdfs:domain :Array ;
+       rdfs:comment "The shape of the enclosing `fdri:Array`"@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/siteVariance
 :siteVariance rdf:type owl:DatatypeProperty ;
               rdfs:range rdf:langString ;
               rdfs:comment "Descriptive information about the way in which the layout of an Environmental Monitoring Facility differs from the standard layout for a facility of its type."@en ;
               rdfs:label "site variance"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/size
+:size rdf:type owl:DatatypeProperty ;
+      rdfs:comment "The size of the enclosing `fdri:Dimension`"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/sourceBucket
@@ -868,6 +898,15 @@ geo:long rdf:type owl:DatatypeProperty ;
 
 Each Annotation instance provides either a single value (`fdri:hasValue`) or a time-based series of values (`fdri:hasValueSeries`) for a single property (`fdri:property`)."""@en ;
             rdfs:label "Annotation"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/Array
+:Array rdf:type owl:Class ;
+       rdfs:subClassOf :GriddedDatasetResource ,
+                       [ rdf:type owl:Restriction ;
+                         owl:onProperty :references ;
+                         owl:minCardinality "0"^^xsd:nonNegativeInteger
+                       ] .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/CatchmentScheme
@@ -1102,6 +1141,11 @@ A Data Processing Configuration is defined as a sub-type of `prov:Plan` allowing
 
 A deployment may be associated with a platform on which the sensors or systems were deployed."""@en ;
             rdfs:label "Deployment"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/Dimension
+:Dimension rdf:type owl:Class ;
+           rdfs:subClassOf :GriddedDatasetResource .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/EnvironmentalDomain
@@ -1672,6 +1716,31 @@ A persistent or unresolved fault may be represented by using an interval with no
                                              ] ;
                              rdfs:comment "A Feature of Interest with a geospatial location."@en ;
                              rdfs:label "Geo-spatial Feature Of Interest"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/GriddedDataset
+:GriddedDataset rdf:type owl:Class ;
+                rdfs:subClassOf :ObservationDataset ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :contains ;
+                                  owl:allValuesFrom :GriddedDatasetResource
+                                ] .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/GriddedDatasetResource
+:GriddedDatasetResource rdf:type owl:Class ;
+                        rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                          owl:onProperty :hasAnnotation ;
+                                          owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                        ] ,
+                                        [ rdf:type owl:Restriction ;
+                                          owl:onProperty :measures ;
+                                          owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                        ] ,
+                                        [ rdf:type owl:Restriction ;
+                                          owl:onProperty sosa:observes ;
+                                          owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                        ] .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/InternalDataProcessingConfiguration

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -1751,11 +1751,11 @@ A persistent or unresolved fault may be represented by using an interval with no
                                           owl:minCardinality "0"^^xsd:nonNegativeInteger
                                         ] ,
                                         [ rdf:type owl:Restriction ;
-                                          owl:onProperty :measures ;
+                                          owl:onProperty :measure ;
                                           owl:minCardinality "0"^^xsd:nonNegativeInteger
                                         ] ,
                                         [ rdf:type owl:Restriction ;
-                                          owl:onProperty sosa:observes ;
+                                          owl:onProperty sosa:observedProperty ;
                                           owl:minCardinality "0"^^xsd:nonNegativeInteger
                                         ] ;
                         rdfs:comment "Base type for resources which form the structure of a Gridded Dataset."@en ;

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -906,7 +906,9 @@ Each Annotation instance provides either a single value (`fdri:hasValue`) or a t
                        [ rdf:type owl:Restriction ;
                          owl:onProperty :references ;
                          owl:minCardinality "0"^^xsd:nonNegativeInteger
-                       ] .
+                       ] ;
+       rdfs:comment "A multi-dimensional array contained in an `fdri:GriddedDataset`."@en ;
+       rdfs:label "Array"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/CatchmentScheme
@@ -1145,7 +1147,9 @@ A deployment may be associated with a platform on which the sensors or systems w
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/Dimension
 :Dimension rdf:type owl:Class ;
-           rdfs:subClassOf :GriddedDatasetResource .
+           rdfs:subClassOf :GriddedDatasetResource ;
+           rdfs:comment "A single dimension of a multi-dimensional array contained in an `fdri:GriddedDataset`."@en ;
+           rdfs:label "Dimension"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/EnvironmentalDomain
@@ -1718,13 +1722,26 @@ A persistent or unresolved fault may be represented by using an interval with no
                              rdfs:label "Geo-spatial Feature Of Interest"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/GriddedContainer
+:GriddedContainer rdf:type owl:Class ;
+                  rdfs:subClassOf :GriddedDatasetResource ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty :contains ;
+                                    owl:allValuesFrom :GriddedDatasetResource
+                                  ] ;
+                  rdfs:comment "A container for gridded data, typically used to organize and manage multiple gridded datasets as a single dataset. Referred to as `groups` in netCDF."@en ;
+                  rdfs:label "Gridded Container"@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/GriddedDataset
 :GriddedDataset rdf:type owl:Class ;
                 rdfs:subClassOf :ObservationDataset ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :contains ;
                                   owl:allValuesFrom :GriddedDatasetResource
-                                ] .
+                                ] ;
+                rdfs:comment "A dataset in an array format such as ZARR or netCDF."@en ;
+                rdfs:label "Gridded Dataset"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/GriddedDatasetResource
@@ -1740,7 +1757,9 @@ A persistent or unresolved fault may be represented by using an interval with no
                                         [ rdf:type owl:Restriction ;
                                           owl:onProperty sosa:observes ;
                                           owl:minCardinality "0"^^xsd:nonNegativeInteger
-                                        ] .
+                                        ] ;
+                        rdfs:comment "Base type for resources which form the structure of a Gridded Dataset."@en ;
+                        rdfs:label "Gridded Dataset Resource"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/InternalDataProcessingConfiguration

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -1413,6 +1413,16 @@ records:
         kind: object
         constraints:
           - record: ObservationDataset
+      keyword:
+        label:
+          - value: keyword
+            lang: en
+        description:
+          - value: A keyword or tag describing a resource.
+            lang: en
+        propertyUri: dcat:keyword
+        kind: literal
+        repeatable: true
       license:
         label:
           - value: license

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -2819,6 +2819,36 @@ records:
     mixins:
       - WithIndexedGeometry
   
+  GriddedContainer:
+    label:
+      - value: Gridded Container
+        lang: en
+    description:
+      - value: A container for gridded data, typically used to organize and manage multiple gridded datasets as a single dataset.
+        lang: en
+    classUri: fdri:GriddedContainer
+    shortCode: GriddedContainer
+    mixins:
+      - WithLabelAndComment
+      - WithAnnotations
+      - WithObservableProperties
+    properties:
+      contains:
+        label:
+          - value: contains
+            lang: en
+        description:
+          - value: The arrays and dimensions contained within the gridded dataset.
+            lang: en
+        propertyUri: fdri:contains
+        kind: object
+        repeatable: true
+        nested: true
+        constraints:
+          - record: Array
+          - record: Dimension
+          - record: GriddedContainer
+
   GriddedDataset:
     label:
       - value: Gridded dataset
@@ -2845,6 +2875,7 @@ records:
         constraints:
           - record: Array
           - record: Dimension
+          - record: GriddedContainer
 
   InternalDataProcessingConfiguration:
     label:

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -62,6 +62,41 @@ mixins:
         repeatable: true
         constraints:
           - datatype: xsd:string
+
+  WithObservableProperties:
+    label:
+      - value: With Observable Properties
+        language: en
+    description:
+      - value: |
+          A resource with reference to observable properties and their measures.
+        language: en
+    properties:
+      measures:
+        label:
+          - value: measures
+            lang: en
+        description:
+          - value: A reference to the `fdri:Measure` that the enclosing resource observes or provides.
+            lang: en
+        propertyUri: fdri:measures
+        kind: object
+        repeatable: true
+        constraints:
+          - record: Measure
+      observes:
+        label:
+          - value: observes
+            lang: en
+        description:
+          - value: |
+              The observable property or properties monitored by, or provided by the enclosing resource.
+        propertyUri: sosa:observes
+        kind: object
+        repeatable: true
+        constraints:
+          - record: Variable
+
   WithAnnotations:
     label:
       - value: With Annotations
@@ -676,6 +711,59 @@ records:
         kind: object
         constraints:
           - record: PropertyValueSeries
+
+  Array:
+    label:
+      - value: Array
+        lang: en
+    description:
+      - value: |
+          A multi-dimensional array contained in an `fdri:GriddedDataset`.
+        lang: en
+    mixins:
+      - WithLabelAndComment
+      - WithAnnotations
+      - WithObservableProperties
+    classUri: fdri:Array
+    shortCode: Array
+    properties:
+      isCoordinate:
+        label:
+          - value: is coordinate
+            lang: en
+        description:
+          - value: A boolean value indicating whether the enclosing fdri:Array is considered to be a co-ordinate variable, having a single dimension of the same name, in the containing netCDF file.
+            lang: en
+        propertyUri: fdri:isCoordinate
+        kind: literal
+        constraints:
+          - datatype: xsd:boolean
+      references:
+        label:
+          - value: references
+            lang: en
+        description:
+          - value: |
+              References to other resources in a gridded dataset are referenced by this array.
+            lang: en
+        propertyUri: fdri:references
+        kind: object
+        repeatable: true
+        nested: true
+        constraints:
+          - record: Array
+          - record: Dimension
+      shape:
+        label:
+          - value: shape
+            lang: en
+        description:
+          - value: |
+              The shape of the array, which may be multi-dimensional.
+            lang: en
+        propertyUri: fdri:shape
+        kind: object
+
 
   Catchment:
     label:
@@ -1552,6 +1640,32 @@ records:
         nested: true
         constraints:
           - record: MediaObject
+
+  Dimension:
+    label:
+      - value: Dimension
+        lang: en
+    description:
+      - value: A single dimension of a multi-dimensional array contained in an `fdri:GriddedDataset`.
+        lang: en
+    mixins:
+      - WithLabelAndComment
+      - WithAnnotations
+      - WithObservableProperties
+    classUri: fdri:Dimension
+    shortCode: Dimension
+    properties:
+      size:
+        label:
+          - value: size
+            lang: en
+        description:
+          - value: The size of the dimension, i.e. the number of elements along this dimension.
+            lang: en
+        propertyUri: fdri:size
+        kind: literal
+        constraints:
+          - datatype: xsd:integer
 
   Distribution:
     label:
@@ -2691,6 +2805,33 @@ records:
     mixins:
       - WithIndexedGeometry
   
+  GriddedDataset:
+    label:
+      - value: Gridded dataset
+        lang: en
+    description:
+      - value: |
+          A dataset containing multi-dimensional arrays of data, typically represented as a grid.
+        lang: en
+    extends: ObservationDataset
+    classUri: fdri:GriddedDataset
+    shortCode: GriddedDataset
+    properties:
+      contains:
+        label:
+          - value: contains
+            lang: en
+        description:
+          - value: The arrays and dimensions contained within the gridded dataset.
+            lang: en
+        propertyUri: fdri:contains
+        kind: object
+        repeatable: true
+        nested: true
+        constraints:
+          - record: Array
+          - record: Dimension
+
   InternalDataProcessingConfiguration:
     label:
       - value: Internal Data Processing Configuration

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -72,26 +72,26 @@ mixins:
           A resource with reference to observable properties and their measures.
         language: en
     properties:
-      measures:
+      measure:
         label:
-          - value: measures
+          - value: measure
             lang: en
         description:
           - value: A reference to the `fdri:Measure` that the enclosing resource observes or provides.
             lang: en
-        propertyUri: fdri:measures
+        propertyUri: fdri:measure
         kind: object
         repeatable: true
         constraints:
           - record: Measure
-      observes:
+      observedProperty:
         label:
-          - value: observes
+          - value: observed property
             lang: en
         description:
           - value: |
               The observable property or properties monitored by, or provided by the enclosing resource.
-        propertyUri: sosa:observes
+        propertyUri: sosa:observedProperty
         kind: object
         repeatable: true
         constraints:
@@ -618,7 +618,18 @@ records:
         repeatable: true
         constraints:
           - datatype: xsd:string
-
+      mbox:
+        label:
+          - value: email
+            lang: en
+        description:
+          - value: An email address of the Agent.
+            lang: en
+        propertyUri: foaf:mbox
+        kind: literal
+        repeatable: true
+        constraints:
+          - datatype: xsd:string
 
   Aggregation:
     label:

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -139,6 +139,7 @@ mixins:
         repeatable: true
         constraints:
           - datatype: rdf:langString
+          - datatype: xsd:string
       comment:
         label:
           - value: comment


### PR DESCRIPTION
* Add fdri:GriddedDatatset for representing multi-dimensional array datasets.
* Add fdri:GriddedContainer, fdri:Array and fdri:Dimension for representing the structure of gridded datasets. These have a common superclass of `fdri:GriddedDatasetResource` and all allow the assertion of labels, annotations and observed properties and measures.