### PR TITLE
Modelling for calibration values

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,7 +28,7 @@ DRAFT 0.5
 * NON-BREAKING: Relax the definition of rdfs:label in the recordspec schema to allow both xsd:string and rdf:langString literals (was only rdf:langString).
 * NON-BREAKING: Add keyword (dcat:keyword) as an optional property of Dataset in the recordspec schema.
 * NEW: Add mbox (`foaf:mbox`) as an allowed property on the `Agent` record type in the recordspec schema.
-* NEW: Allow `hasAnnotation` on `GeospatialFeatureOfInterest`.
+* NEW: Add type `fdri:CalibrationValueSeries` to record sensor calibration coefficients. Add property `fdri:calibrationValue` to relates an `fdri:EnvironmentalMonitoringSystem` to the `fdri:CalibrationValueSeries` that apply to the variables measured by that system.
 
 DRAFT 0.4.2
 -----------

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -123,6 +123,14 @@ geo:location rdf:type owl:AnnotationProperty ;
           rdfs:label "argument"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/calibrationValue
+:calibrationValue rdf:type owl:ObjectProperty ;
+                  rdfs:domain :EnvironmentalMonitoringSystem ;
+                  rdfs:range :CalibrationValueSeries ;
+                  rdfs:comment "Relates an `fdri:EnvironmentalMonitoringSystem` to the `fdri:CalibrationValueSeries` that provide the calibration co-efficients for the system."@en ;
+                  rdfs:label "calibration value"@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/catchmentScheme
 :catchmentScheme rdf:type owl:ObjectProperty ;
                  rdfs:subPropertyOf dcat:themeTaxonomy ;
@@ -909,6 +917,23 @@ Each Annotation instance provides either a single value (`fdri:hasValue`) or a t
                        ] ;
        rdfs:comment "A multi-dimensional array contained in an `fdri:GriddedDataset`."@en ;
        rdfs:label "Array"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/CalibrationValueSeries
+:CalibrationValueSeries rdf:type owl:Class ;
+                        rdfs:subClassOf :PropertyValueSeries ,
+                                        [ rdf:type owl:Restriction ;
+                                          owl:onProperty :appliesToVariable ;
+                                          owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                          owl:onClass :Variable
+                                        ] ,
+                                        [ rdf:type owl:Restriction ;
+                                          owl:onProperty :method ;
+                                          owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                          owl:onClass :DataProcessingMethod
+                                        ] ;
+                        rdfs:comment "A series of calibration co-efficients to be used to correct the raw values of the specified variable using the specified data processing method."@en ;
+                        rdfs:label "Calibration Value Series"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/CatchmentScheme

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -790,6 +790,31 @@ records:
         propertyUri: fdri:shape
         kind: object
 
+  CalibrationValueSeries:
+    label:
+      - value: Calibration Value Series
+        lang: en
+    description:
+      - value: A series of calibration values to be applied to the raw values of a specific variable, using a specific calibration method to provide the calibrated values.
+        lang: en
+    extends: PropertyValueSeries
+    classUri: fdri:CalibrationValueSeries
+    shortCode: CalibrationValueSeries
+    properties:
+      appliesToVariable:
+        description:
+          - value: The variable that this calibration series provides calibration values for.
+        propertyUri: fdri:appliesToVariable
+        kind: object
+        constraints:
+          - record: Variable
+      method:
+        description:
+          - value: A reference to the concept that defines the calibration method to be used when applying the values in this series.
+        propertyUri: fdri:method
+        kind: object
+        constraints:
+          - record: DataProcessingMethod
 
   Catchment:
     label:
@@ -2231,6 +2256,17 @@ records:
         kind: literal
         constraints:
           - datatype: xsd:string
+      calibrationValue:
+        label:
+          - value: calibration value
+            lang: en
+        description:
+          - value: The calibration co-efficients or settings that were determined when the system was calibrated.
+            lang: en
+        propertyUri: fdri:calibrationValue
+        kind: object
+        constraints:
+          - record: CalibrationValueSeries
       calibrationDue:
         label:
           - value: calibration due


### PR DESCRIPTION
Addresses #47
* Add fdri:CalibrationValueSeries to record a series of calibration values for a given variable and data processing method.
* Add fdri:calibrationValue to relate an `fdri:EnvironmentalMonitoringSystem` to the `fdri:CalibrationValueSeries` that provide calibration co-efficients for that system.