### PR TITLE
Add provenance tracking to calibration value series

### DIFF
--- a/doc/sensor-calibration-values.md
+++ b/doc/sensor-calibration-values.md
@@ -37,3 +37,24 @@ CalibrationMethod --> Method: fdri_method
 EMSystemType --> CalibrationMethod: fdri_hasCalibrationMethod
 EMSystem --> EMSystemType: dct_type
 ```
+
+### Calibration activities and provenance
+
+The `fdri:CalibrationValueSeries` class supports provenance statements that can link the update of the value series to sensor calibration activity/activities.
+
+```mermaid
+---
+config:
+    class:
+        hideEmptyMembersBox: true
+---
+classDiagram
+class CalibrationValueSeries["fdri:CalibrationValueSeries"]
+class Activity["prov:Activity"]
+
+CalibrationValueSeries --> Activity: prov_wasGeneratedBy
+CalibrationValueSeries --> Activity: fdri_wasModifiedBy
+```
+
+> [!NOTE]
+> The provenance tracking is at the level of the `fdir:CalibrationValueSeries`, not on each value in the series making it possible to see in one place all of the activities that have affected a givent calibration coefficient for a sensor.

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -955,6 +955,7 @@ Each Annotation instance provides either a single value (`fdri:hasValue`) or a t
 ###  http://fdri.ceh.ac.uk/vocab/metadata/CalibrationValueSeries
 :CalibrationValueSeries rdf:type owl:Class ;
                         rdfs:subClassOf :PropertyValueSeries ,
+                                        prov:Entity ,
                                         [ rdf:type owl:Restriction ;
                                           owl:onProperty :appliesToVariable ;
                                           owl:minCardinality "1"^^xsd:nonNegativeInteger

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -848,6 +848,8 @@ records:
     classUri: fdri:CalibrationValueSeries
     shortCode: CalibrationValueSeries
     extends: PropertyValueSeries
+    mixins:
+      - WithProvenance
     properties:
       appliesToVariable:
         label:


### PR DESCRIPTION
In order to link the calibration coefficients to the calibration activities that produced them, I've updated to model to make an `fdri:CalibrationValueSeries` a subclass of `prov:Entity` which allows it to be the target of `prov:wasGeneratedBy`/`fdri:wasModifiedBy` properties.