### PR TITLE
Add fdri:sourceTimeColumnName property

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,7 +33,8 @@ DRAFT 0.5
 * NON-BREAKING: Changed the range of `fdri:property` on `fdri:Annotation` from `fdri:Variable` to the super-class `skos:Concept`, to allow any kind of Concept to be used to define an annotation property.
 * FIX: Fix typo in the URI of the `deployedHeight` property on the `StaticDeployment` record in the Recordspec model.
 * NON-BREAKING: Relax the definition of `fdri:Variable` so that the IAdopt properties `iop:hasProperty` and `iop:hasObjectOfInterest` are optional.
-* NEW: Added foaf:homepage property to `fdri:EnvironmentalMonitoringProgramme` and `fdri:EnvironmenalMonitoringNetwork`
+* NEW: Added `foaf:homepage` property to `fdri:EnvironmentalMonitoringProgramme` and `fdri:EnvironmenalMonitoringNetwork`
+* NEW: Added `fdri:sourceTimeColumnName` to `fdri:TimeSeriesDataset` to capture the name of the column that holds the timestamp for each observation. 
 
 DRAFT 0.4.2
 -----------

--- a/owl/catalog-v001.xml
+++ b/owl/catalog-v001.xml
@@ -13,7 +13,6 @@
     <uri id="Imports Wizard Entry" name="http://www.w3.org/ns/ssn/" uri="https://www.w3.org/ns/ssn/"/>
     <uri id="User Edited Redirect" name="http://www.w3.org/ns/dcat3" uri="dcat3.ttl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1763632933502" name="http://data.ordnancesurvey.co.uk/ontology/spatialrelations/" uri="spatialrelations.owl"/>
-        <uri id="Automatically generated entry, Timestamp=1763632933502" name="https://w3id.org/iadopt/ont" uri="iadopt-1.0.3.xml"/>
+        <uri id="Automatically generated entry, Timestamp=1765877634737" name="http://data.ordnancesurvey.co.uk/ontology/spatialrelations/" uri="spatialrelations.owl"/>
     </group>
 </catalog>

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -811,6 +811,13 @@ More specific sub-properties `fdri:dependencyNote` and `fdri:deploymentVariance`
                rdfs:label "source dataset"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/sourceTimeColumnName
+:sourceTimeColumnName rdf:type owl:DatatypeProperty ;
+                      rdfs:range xsd:string ;
+                      rdfs:comment "Provides the name of the column within the source dataset which provides the timestamps associated with the observations contained in an FDRI time series dataset."@en ;
+                      rdfs:label "source timestamp column name"@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/storageLocation
 :storageLocation rdf:type owl:DatatypeProperty ;
                  rdfs:range xsd:string ;
@@ -2334,6 +2341,10 @@ In addition the use of `schema:minValue`, `schema:maxValue`, `schema:value` and 
                                    ] ,
                                    [ rdf:type owl:Restriction ;
                                      owl:onProperty :sourceDataset ;
+                                     owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty :sourceTimeColumnName ;
                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                    ] ;
                    rdfs:comment """A Observation Dataset consisting of a collection of values of one or more Measures of some Feature of Interest at regular intervals over a period of time.

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -4467,7 +4467,7 @@ records:
           - value: originating site
             lang: en
         description:
-          - value: The environmental monitoring site whic provided some portion of the content of this dataset.
+          - value: The environmental monitoring site which provided some portion of the content of this dataset.
             lang: en
         propertyUri: fdri:originatingSite
         kind: object
@@ -4481,7 +4481,7 @@ records:
         description:
           - value: |
               Provides the identifier of the S3 bucket which contains the source data processed to create or update
-              time series datasets using this definition.
+              the enclosing TimeSeriesDataset.
             language: en
         propertyUri: fdri:sourceBucket
         kind: literal
@@ -4494,7 +4494,7 @@ records:
         description:
           - value: |
               Provides the name of the column within the source dataset which provides the values to be processed to 
-              create or update time series datasets using this definition.
+              create or update the enclosing TimeSeriesDataset.
             language: en
         propertyUri: fdri:sourceColumnName
         kind: literal
@@ -4507,8 +4507,21 @@ records:
         description:
           - value: |
               Provides the identifier of the partition within the source bucket which contains the source data to be
-              processed to create or update time series datasets using this definition.
+              processed to create or update the enclosing TimeSeriesDataset.
         propertyUri: fdri:sourceDataset
+        kind: literal
+        constraints:
+          - datatype: xsd:string
+      sourceTimeColumnName:
+        label:
+          - value: source timestamp column name
+            language: en
+        description:
+          - value: |
+              Provides the name of the column within the source dataset which provides the timestamps associated with
+              the values to be processed to create or update the enclosing TimeSeriesDataset.
+            language: en
+        propertyUri: fdri:sourceTimeColumnName
         kind: literal
         constraints:
           - datatype: xsd:string


### PR DESCRIPTION
Allows the capture of the name of the column that provides timestamp values for observations. As requested on  NERC-CEH/fdri-discovery#250