### PR TITLE
Add fdri:utilisedBy as inverse of fdri:utilises

### DIFF
--- a/doc/emf.md
+++ b/doc/emf.md
@@ -70,7 +70,9 @@ class Measure["fdri:Measure"]
 
 Resource <|-- Facility
 Programme --> Network: fdri_utilises
+Network --> Programme: fdri_utilisedBy
 Programme --> Facility: fdri_utilises
+Facility --> Programme: fdri_utilisedBy
 Network --> Facility: fdri_contains
 Facility --> RelatedParty: prov_qualifiedAttribution
 RelatedParty --> AgentRole: dcat_hadRole

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -480,6 +480,14 @@ When `fdri:hasValue` is present on an item, this property SHOULD NOT be present 
       rdfs:label "uses"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/utilisedBy
+:utilisedBy rdf:type owl:ObjectProperty ;
+            owl:inverseOf :utilises ;
+            rdfs:range :EnvironmentalMonitoringProgramme ;
+            rdfs:comment "A reference to the Environmental Monitoring Programme(s) that use this monitoring network or facility in the achievement of their environmental monitoring aims."@en ;
+            rdfs:label "utilised by"@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/utilises
 :utilises rdf:type owl:ObjectProperty ;
           rdfs:domain :EnvironmentalMonitoringProgramme ;

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -2114,6 +2114,19 @@ records:
         kind: object
         constraints:
           - record: EnvironmentalMonitoringFacilityType
+      utilisedBy:
+        label:
+          - value: utilised by
+            lang: en
+        description:
+          - value: |
+              A reference to the Environmental Monitoring Programme(s) that use this monitoring network or facility in the achievement of their environmental monitoring aims.
+            lang: en
+        propertyUri: fdri:utilisedBy
+        kind: object
+        repeatable: true
+        constraints:
+          - record: EnvironmentalMonitoringProgramme
 
   EnvironmentalMonitoringFacilityType:
     label:
@@ -2205,6 +2218,19 @@ records:
         repeatable: true
         constraints:
           - record: EnvironmentalMonitoringFacility
+      utilisedBy:
+        label:
+          - value: utilised by
+            lang: en
+        description:
+          - value: |
+              A reference to the Environmental Monitoring Programme(s) that use this monitoring network in the achievement of their environmental monitoring aims.
+            lang: en
+        propertyUri: fdri:utilisedBy
+        kind: object
+        repeatable: true
+        constraints:
+          - record: EnvironmentalMonitoringProgramme
 
   EnvironmentalMonitoringPlatform:
     label:


### PR DESCRIPTION
Added to provide a way to reference the programme(s) that use a site as a direct property of the site rather than having to traverse the existing `fdri:utilises` property in reverse direction. 