### PR TITLE
Change lat/long and easting/northing to decimal values

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@ DRAFT 0.5
 * NEW: Added `foaf:homepage` property to `fdri:EnvironmentalMonitoringProgramme` and `fdri:EnvironmenalMonitoringNetwork`
 * NEW: Added `fdri:sourceTimeColumnName` to `fdri:TimeSeriesDataset` to capture the name of the column that holds the timestamp for each observation. 
 * BREAKING: Replaced `fdri:reference` with `fdri:referenceList` on `fdri:Array`. This allows for the items in a gridded data array to be assigned an index that indicates the item's index in the storage array of the underlying gridded dataset. 
+* BREAKING: Change the range of geo:lat, geo:long, spatialrelations:easting and spatialrelations:northing from string to decimal to enable numeric comparison in SPARQL queries.
 
 DRAFT 0.4.2
 -----------

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -1353,12 +1353,12 @@ An EnvironmentalMonitoringActivity may follow a documented Procedure, and may in
                                                  [ rdf:type owl:Restriction ;
                                                    owl:onProperty spatialrelations:easting ;
                                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                                   owl:onDataRange xsd:string
+                                                   owl:onDataRange xsd:decimal
                                                  ] ,
                                                  [ rdf:type owl:Restriction ;
                                                    owl:onProperty spatialrelations:northing ;
                                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                                   owl:onDataRange xsd:string
+                                                   owl:onDataRange xsd:decimal
                                                  ] ,
                                                  [ rdf:type owl:Restriction ;
                                                    owl:onProperty :isMobile ;
@@ -1367,12 +1367,12 @@ An EnvironmentalMonitoringActivity may follow a documented Procedure, and may in
                                                  [ rdf:type owl:Restriction ;
                                                    owl:onProperty geo:lat ;
                                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                                   owl:onDataRange xsd:string
+                                                   owl:onDataRange xsd:decimal
                                                  ] ,
                                                  [ rdf:type owl:Restriction ;
                                                    owl:onProperty geo:long ;
                                                    owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                                   owl:onDataRange xsd:string
+                                                   owl:onDataRange xsd:decimal
                                                  ] ;
                                  rdfs:comment """A piece of infrastructure used by an environmental monitoring programme for some purpose.
 
@@ -1646,22 +1646,22 @@ The `dct:type` property of this class SHOULD be used to reference the `fdri:Data
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty spatialrelations:easting ;
                                  owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                 owl:onDataRange xsd:string
+                                 owl:onDataRange xsd:decimal
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty spatialrelations:northing ;
                                  owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                 owl:onDataRange xsd:string
+                                 owl:onDataRange xsd:decimal
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty geo:lat ;
                                  owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                 owl:onDataRange xsd:string
+                                 owl:onDataRange xsd:decimal
                                ] ,
                                [ rdf:type owl:Restriction ;
                                  owl:onProperty geo:long ;
                                  owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                 owl:onDataRange xsd:string
+                                 owl:onDataRange xsd:decimal
                                ] ;
                rdfs:comment """Represents a collection of related Environmental Monitoring Facilities.
 
@@ -1789,22 +1789,22 @@ A persistent or unresolved fault may be represented by using an interval with no
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty spatialrelations:easting ;
                                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                               owl:onDataRange xsd:string
+                                               owl:onDataRange xsd:decimal
                                              ] ,
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty spatialrelations:northing ;
                                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                               owl:onDataRange xsd:string
+                                               owl:onDataRange xsd:decimal
                                              ] ,
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty geo:lat ;
                                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                               owl:onDataRange xsd:string
+                                               owl:onDataRange xsd:decimal
                                              ] ,
                                              [ rdf:type owl:Restriction ;
                                                owl:onProperty geo:long ;
                                                owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                               owl:onDataRange xsd:string
+                                               owl:onDataRange xsd:decimal
                                              ] ;
                              rdfs:comment "A Feature of Interest with a geospatial location."@en ;
                              rdfs:label "Geo-spatial Feature Of Interest"@en .

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -410,7 +410,7 @@ mixins:
         propertyUri: geo:lat
         kind: literal
         constraints:
-          - datatype: xsd:string
+          - datatype: xsd:decimal
       long:
         label:
           - value: longitude of representative point
@@ -422,7 +422,7 @@ mixins:
         propertyUri: geo:long
         kind: literal
         constraints:
-          - datatype: xsd:string
+          - datatype: xsd:decimal
       easting:
         label:
           - value: easting of representative point
@@ -434,7 +434,7 @@ mixins:
         propertyUri: spatialrelations:easting
         kind: literal
         constraints:
-          - datatype: xsd:string
+          - datatype: xsd:decimal
       northing:
         label:
           - value: northing of representative point
@@ -446,7 +446,7 @@ mixins:
         propertyUri: spatialrelations:northing
         kind: literal
         constraints:
-          - datatype: xsd:string
+          - datatype: xsd:decimal
 
   WithValueOrRange:
     label:


### PR DESCRIPTION
Change the lat/long and easting/northing properties from being strings to being numeric (decimal) values in the model. 

Enforcing this in the RDF makes it possible to do some basic maths in SPARQL queries to support simple bounding box and bounding circle geospatial queries. It is also arguably the "correct" choice for the representation of these values as it would flag invalid non-numeric values.

This should be considered a breaking change as it will alter the JSON values from string to numeric, which may affect downstream users.
