### PR TITLE
Extend range of fdri:uses property. 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,7 @@ DRAFT 0.5
 * BREAKING: Change the range of geo:lat, geo:long, spatialrelations:easting and spatialrelations:northing from string to decimal to enable numeric comparison in SPARQL queries.
 * NON-BREAKIMG: Relax definition of `TimeSeriesDataset` to make the `type` property optional in the schema.
 * NON-BREAKING: Add optional `fdri:hasStructuredValue` property to `fdri:ConfigurationArgument` to cover the case where the value of an argument is a complex value consisting of a set of key-value pairs. Each key-value pair is represented as a separate fdri:ConfigurationArgument, allowing for further nesting of structured values if needed.
+* NON-BREAKING: Extend range of `fdri:uses` from `fdri:TimeSeriesDefinition` only, to `fdri:TimeSeriesDataset` or `fdri:TimeSeriesDefinition`.
 
 DRAFT 0.4.2
 -----------

--- a/doc/time-series-dataset.md
+++ b/doc/time-series-dataset.md
@@ -51,6 +51,7 @@ TimeSeriesDefinition --> Variable: sosa_observedProperty
 TimeSeriesDefinition --> Measure: fdri_measure
 TimeSeriesDefinition --> Plan: fdri_methodology
 Plan --> TimeSeriesDefinition: fdri_uses
+Plan --> TimeSeriesDataset: fdri_uses
 TimeSeriesDataset --> ProcessingLevel: fdri_processingLevel
 TimeSeriesDataset --> Variable: sosa_observedProperty
 TimeSeriesDataset --> Measure: fdri_measure
@@ -62,7 +63,7 @@ An `fdri:TimeSeriesDataset` represents a dataset that consists of a time-series 
 * `fdri:processingLevel` a reference to the concept that defines the level of data processing applied to the time series. This property is repeated on `fdri:TimeSeriesDataset` to ensure consistency with the `fdri:ObservationDataset` base class.
 * `sosa:observedProperty` a reference to the `iop:Variable` that defines the property being observed by the dataset. This property is repeated on `fdri:TimeSeriesDataset` to ensure consitency with the `fdri:ObservationDataset` base class.
 * `fdri:measure` a reference to the `fdri:Measure` that defines measurements recorded in the dataset. This property is repeated on `fdri:TimeSeriesDataset` to ensure consistency with the `fdri:ObservationDataset` base class.
-* `fdri:methodology` a reference to the `fdri:TimeSeriesPlan` which documents the method by which the dataset is produced. Where a time series is produced by derivation from one or more input time series, the `fdri:uses` relation relates the `fdri:TimeSeriesPlan` to the input time series.
+* `fdri:methodology` a reference to the `fdri:TimeSeriesPlan` which documents the method by which the dataset is produced. Where a time series is produced by derivation from one or more input time series, the `fdri:uses` relation relates the `fdri:TimeSeriesPlan` to the input time series, either by direct reference to the `fdri:TimeSeriesDataset` or to the `fdri:TimeSeriesDefinition` that types the input dataset.
 * `fdri:sourceBucket` specifies the top level container (an S3 bucket) in which the data that is processed to produce time series datasets is stored.
 * `fdri:dataset` specifies the specific partition of the top level container in which the data is stored.
 * `fdri:columName` specifies the column within the partition where the values that produce the time series dataset(s) is stored.

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -481,7 +481,11 @@ When `fdri:hasValue` is present on an item, this property SHOULD NOT be present 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/uses
 :uses rdf:type owl:ObjectProperty ;
-      rdfs:range :TimeSeriesDefinition ;
+      rdfs:range [ rdf:type owl:Class ;
+                   owl:unionOf ( :TimeSeriesDataset
+                                 :TimeSeriesDefinition
+                               )
+                 ] ;
       rdfs:comment "Relates a Time Series Plan for the production of some Time Series to the Time Series Definitions that define the input Time Series used by the plan."@en ;
       rdfs:label "uses"@en .
 

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -4700,6 +4700,7 @@ records:
         repeatable: true
         constraints:
           - record: TimeSeriesDefinition
+          - record: TimeSeriesDataset
       configuration:
         propertyUri: fdri:configuration
         kind: object


### PR DESCRIPTION
Allow fdri:TimeSeriesDataset as the target of the fdri:uses property in addition to existing fdri:TimeSeriesDefinition.