### PR TITLE
Allow dataset-specific methodology

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,8 @@ DRAFT 0.5
 * NON-BREAKIMG: Relax definition of `TimeSeriesDataset` to make the `type` property optional in the schema.
 * NON-BREAKING: Add optional `fdri:hasStructuredValue` property to `fdri:ConfigurationArgument` to cover the case where the value of an argument is a complex value consisting of a set of key-value pairs. Each key-value pair is represented as a separate fdri:ConfigurationArgument, allowing for further nesting of structured values if needed.
 * NON-BREAKING: Extend range of `fdri:uses` from `fdri:TimeSeriesDefinition` only, to `fdri:TimeSeriesDataset` or `fdri:TimeSeriesDefinition`.
+* NEW: Add `fdri:rawConfiguration` property to `fdri:TimeSeriesPlan` to record the JSON configuration for the plan.
+* NEW: Allow `fdri:methodology` on an `fdri:TimeSeriesDataset` to allow dataset-specific processing plans to be described.
 
 DRAFT 0.4.2
 -----------

--- a/owl/catalog-v001.xml
+++ b/owl/catalog-v001.xml
@@ -13,6 +13,6 @@
     <uri id="Imports Wizard Entry" name="http://www.w3.org/ns/ssn/" uri="https://www.w3.org/ns/ssn/"/>
     <uri id="User Edited Redirect" name="http://www.w3.org/ns/dcat3" uri="dcat3.ttl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=true, version=2" prefer="public" xml:base="">
-        <uri id="Automatically generated entry, Timestamp=1765877634737" name="http://data.ordnancesurvey.co.uk/ontology/spatialrelations/" uri="spatialrelations.owl"/>
+        <uri id="Automatically generated entry, Timestamp=1769174803767" name="http://data.ordnancesurvey.co.uk/ontology/spatialrelations/" uri="spatialrelations.owl"/>
     </group>
 </catalog>

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -587,6 +587,12 @@ sosa:observedProperty schema:domainIncludes :ObservationDataset .
 #    Data properties
 #################################################################
 
+###  http://fdri.ceh.ac.uk/vocab/metadata#rawConfiguration
+:rawConfiguration rdf:type owl:DatatypeProperty ;
+                  rdfs:comment "The raw JSON configuration for the execution of the enclosing Plan."@en ;
+                  rdfs:label "raw configuration"@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/aggregationPeriod
 :aggregationPeriod rdf:type owl:DatatypeProperty ;
                    rdfs:range xsd:duration ;
@@ -1962,6 +1968,10 @@ A current configuration MAY consist of multiple `fdri:ConfigurationItem` instanc
 :ObservationDataset rdf:type owl:Class ;
                     rdfs:subClassOf dcat:Dataset ,
                                     [ rdf:type owl:Restriction ;
+                                      owl:onProperty :methodology ;
+                                      owl:allValuesFrom :TimeSeriesPlan
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
                                       owl:onProperty dcat:inSeries ;
                                       owl:allValuesFrom :ObservationDatasetSeries
                                     ] ,
@@ -2455,6 +2465,10 @@ A Time-Series Definition captures the information that is common across multiple
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :uses ;
                                   owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty :rawConfiguration ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
                                 ] ;
                 rdfs:comment "A procedure which results in the creation or update of instances of a Time-Series Definition (`fdri:TimeSeriesDefinition`) through the application of one or more data processing configurations (`fdri:DataProcessingConfiguration`) to it's input time series."@en ;
                 rdfs:label "Time-series Plan"@en .

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -4546,6 +4546,11 @@ records:
     classUri: fdri:TimeSeriesDataset
     shortCode: TimeSeriesDataset
     properties:
+      methodology:
+        propertyUri: fdri:methodology
+        kind: object
+        constraints:
+          - record: TimeSeriesPlan
       dependsOn:
         label:
           - value: depends on
@@ -4707,6 +4712,18 @@ records:
         repeatable: false
         constraints:
           - record: DataProcessingConfiguration
+      rawConfiguration:
+        label:
+          - value: raw configuration
+            lang: en
+        description:
+          - value: |
+              A JSON representation of the raw configuration used by the data processing system to implement this plan.
+            lang: en
+        propertyUri: fdri:rawConfiguration
+        kind: literal
+        constraints:
+          - datatype: xsd:string
   Unit:
     label:
       - value: Unit Of Measure


### PR DESCRIPTION
* Allow `fdri:methodology` on `fdri:TimeSeriesDataset` to link to a dataset-specific processing plan.
* Add new property `fdri:rawConfiguration` to `fdri:TimeSeriesPlan` to store the raw JSON configuration string for the plan.