### PR TITLE
Time Series Processing changes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,7 +17,8 @@ DRAFT 0.6
 * BREAKING: Change `hasAnnotation` to a nested property
 * BREAKING: Change `hasValue` and `hasValueSeries` on `Annotation` to nested properties
 * BREAKING: Change `hasOperatingRange`, `hasSurvivalRange` and `hasSystemCapability` to nested properties
-* BREAKING: Change `interval` on `FacilityGroupMembership`, `Fault` to a nested property
+* BREAKING: Change `interval` on `FacilityGroupMembership`, `Fault` to a nested Property
+* BREAKING: Changes made to the way that a Time-Series Plan is represented. A plan now consists of a series of steps, each with its own index number and configuration.
 
 DRAFT 0.5
 ---------

--- a/doc/time-series-dataset.md
+++ b/doc/time-series-dataset.md
@@ -54,7 +54,7 @@ class Plan["fdri:TimeSeriesPlan"] {
     rawConfiguration: xsd:string
 }
 class Step["fdri:TimeSeriesPlanStep"] {
-    stepNumber: xsd:integer
+    index: xsd:integer
     rawConfiguration: xsd:string
 }
 class DataProcessingConfiguration["fdri:DataProcessingConfiguration"]
@@ -67,7 +67,7 @@ TimeSeriesDataset --> Variable: sosa_observedProperty
 TimeSeriesDataset --> Measure: fdri_measure
 TimeSeriesDataset --> Plan: fdri_methodology
 Plan --> ObservationDataset: fdri_uses
-Plan --> Step: fdri_hasStep
+Plan --> Step: dct_hasPart
 Step --> DataProcessingConfig: fdri_configuration
 TimeSeriesDataset --> TimeSeriesDataset: fdri_dependsOn, fdri_directDependsOn
 ```
@@ -85,23 +85,21 @@ The following additional properties are defined for an `fdri:TimeSeriesDataset`.
 The `fdri:TimeSeriesPlan` has the following properties:
 
 * `fdri:uses` references the primary input dataset(s) for the processing plan.
-* `fdri:hasSteps` references the steps of the processing plan
+* `dct:hasPart` references the steps of the processing plan.
 * `fdri:rawConfiguration` is a JSON array of the identifiers of the data processing configurations of each step in step order, serialised as a string.
 
 Each `fdri:TimeSeriesPlanStep` consists of the following properties:
 
-* `fdri:stepNumber` provides an integer step number (steps being processed in order from the lowest numbered step to the highest numbered step)
-* `fdri:configuration` provides a reference to the `fdri:DataProcessingConfiguration` that defines the step process
+* `fdri:index` provides an integer step number (steps being processed in order from the lowest numbered step to the highest numbered step).
+* `fdri:configuration` provides a reference to the `fdri:DataProcessingConfiguration` that defines the step process.
 * `fdri:rawConfiguration` property which provides a JSON representation of the data processing configuration.
 
 > **NOTE**
 > The datasets for different sites are saved in separate folders within the same path structure within the bucket. This is expected to be the case for other projects processed through the DRI pipeline, and so site specific paths are not currently specified in the time series definition metadata.
 
-
 ### Time-Series Dataset Versioning
 
 For each time-series, there is a dataset resource representing the time-series (the "versioned dataset") and a separate resource for each version of the time-series (the "dataset version"). A new version is created whenever a new processing pipeline is applied to the raw data and each version of the time series will have a different DOI.
-
 
 ```mermaid
 flowchart

--- a/doc/time-series-dataset.md
+++ b/doc/time-series-dataset.md
@@ -50,7 +50,14 @@ class TimeSeriesDataset["fdri:TimeSeriesDataset"] {
   fdri:sourceDataset: xsd:string
   fdri:sourceColumnName: xsd:string
 }
-class Plan["fdri:TimeSeriesPlan"]
+class Plan["fdri:TimeSeriesPlan"] {
+    rawConfiguration: xsd:string
+}
+class Step["fdri:TimeSeriesPlanStep"] {
+    stepNumber: xsd:integer
+    rawConfiguration: xsd:string
+}
+class DataProcessingConfiguration["fdri:DataProcessingConfiguration"]
 class ProcessingLevel["fdri:ProcessingLevel"]
 class Variable["skos:Concept"]
 class Measure["fdri:Measure"]
@@ -59,7 +66,9 @@ TimeSeriesDataset --> ProcessingLevel: fdri_processingLevel
 TimeSeriesDataset --> Variable: sosa_observedProperty
 TimeSeriesDataset --> Measure: fdri_measure
 TimeSeriesDataset --> Plan: fdri_methodology
-Plan --> TimeSeriesDataset: fdri_uses
+Plan --> ObservationDataset: fdri_uses
+Plan --> Step: fdri_hasStep
+Step --> DataProcessingConfig: fdri_configuration
 TimeSeriesDataset --> TimeSeriesDataset: fdri_dependsOn, fdri_directDependsOn
 ```
 
@@ -67,11 +76,23 @@ An `fdri:TimeSeriesDataset` represents a dataset that consists of a time-series 
 
 The following additional properties are defined for an `fdri:TimeSeriesDataset`.
 
-* `fdri:methodology` a reference to the `fdri:TimeSeriesPlan` which documents the method by which the dataset is produced. Where a time series is produced by derivation from one or more input time series, the `fdri:uses` relation relates the `fdri:TimeSeriesPlan` to the input time series, either by direct reference to the `fdri:TimeSeriesDataset` or to the `fdri:TimeSeriesDefinition` that types the input dataset.
+* `fdri:methodology` a reference to the `fdri:TimeSeriesPlan` which documents the method by which the dataset is produced.
 * `fdri:sourceBucket` specifies the top level container (an S3 bucket) in which the data that is processed to produce time series datasets is stored.
 * `fdri:dataset` specifies the specific partition of the top level container in which the data is stored.
 * `fdri:columName` specifies the column within the partition where the values that produce the time series dataset(s) is stored.
 * `fdri:dependsOn` and `fdri:directDependsOn` express processing dependencies between TimeSeriesDatasets. `fdri:directDependsOn` should be used only for direct dependencies and `fdri:dependsOn` may be used to capture the transitive closure of `fdri:directDependsOn`. The precise nature of the dependency between datasets should be captured by the `fdri:TimeSeriesPlan` associated with the dataset.
+
+The `fdri:TimeSeriesPlan` has the following properties:
+
+* `fdri:uses` references the primary input dataset(s) for the processing plan.
+* `fdri:hasSteps` references the steps of the processing plan
+* `fdri:rawConfiguration` is a JSON array of the identifiers of the data processing configurations of each step in step order, serialised as a string.
+
+Each `fdri:TimeSeriesPlanStep` consists of the following properties:
+
+* `fdri:stepNumber` provides an integer step number (steps being processed in order from the lowest numbered step to the highest numbered step)
+* `fdri:configuration` provides a reference to the `fdri:DataProcessingConfiguration` that defines the step process
+* `fdri:rawConfiguration` property which provides a JSON representation of the data processing configuration.
 
 > **NOTE**
 > The datasets for different sites are saved in separate folders within the same path structure within the bucket. This is expected to be the case for other projects processed through the DRI pipeline, and so site specific paths are not currently specified in the time series definition metadata.

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -2628,12 +2628,13 @@ A Time-Series Definition captures the information that is common across multiple
 :TimeSeriesPlan rdf:type owl:Class ;
                 rdfs:subClassOf :Procedure ,
                                 [ rdf:type owl:Restriction ;
-                                  owl:onProperty :configuration ;
-                                  owl:allValuesFrom :DataProcessingConfiguration
+                                  owl:onProperty dct:hasPart ;
+                                  owl:allValuesFrom :TimeSeriesPlanStep
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :uses ;
-                                  owl:minCardinality "0"^^xsd:nonNegativeInteger
+                                  owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+                                  owl:onClass :ObservationDataset
                                 ] ,
                                 [ rdf:type owl:Restriction ;
                                   owl:onProperty :rawConfiguration ;
@@ -2641,6 +2642,26 @@ A Time-Series Definition captures the information that is common across multiple
                                 ] ;
                 rdfs:comment "A procedure which results in the creation or update of instances of a Time-Series Definition (`fdri:TimeSeriesDefinition`) through the application of one or more data processing configurations (`fdri:DataProcessingConfiguration`) to it's input time series."@en ;
                 rdfs:label "Time-series Plan"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/TimeSeriesPlanStep
+:TimeSeriesPlanStep rdf:type owl:Class ;
+                    rdfs:subClassOf :Procedure ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :configuration ;
+                                      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                      owl:onClass :DataProcessingConfiguration
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :index ;
+                                      owl:cardinality "1"^^xsd:nonNegativeInteger
+                                    ] ,
+                                    [ rdf:type owl:Restriction ;
+                                      owl:onProperty :rawConfiguration ;
+                                      owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                    ] ;
+                    rdfs:comment "A processing step in a Time-series Plan, representing the application of a single algorithm or method to one or more input datasets to produce one or more output datasets."@en ;
+                    rdfs:label "Time-series Plan Step"@en .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/Unit

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -4902,6 +4902,28 @@ records:
         repeatable: true
         constraints:
           - record: ObservationDataset
+      hasStep:
+        propertyUri: fdri:hasStep
+        kind: object
+        repeatable: true
+        constraints:
+          - record: TimeSeriesPlanStep
+
+  TimeSeriesPlanStep:
+    classUri: fdri:TimeSeriesPlanStep
+    shortCode: TimeSeriesPlanStep
+    properties:
+      stepNumber:
+        label:
+          - value: step number
+            lang: en
+        description:
+          - value: The sequential number of this step within the plan.
+            lang: en
+        propertyUri: fdri:stepNumber
+        kind: literal
+        constraints:
+          - datatype: xsd:integer
       configuration:
         propertyUri: fdri:configuration
         kind: object
@@ -4914,7 +4936,7 @@ records:
             lang: en
         description:
           - value: |
-              A JSON representation of the raw configuration used by the data processing system to implement this plan.
+              A JSON representation of the raw configuration used by the data processing system to implement this plan step.
             lang: en
         propertyUri: fdri:rawConfiguration
         kind: literal

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -4902,8 +4902,8 @@ records:
         repeatable: true
         constraints:
           - record: ObservationDataset
-      hasStep:
-        propertyUri: fdri:hasStep
+      hasPart:
+        propertyUri: dct:hasPart
         kind: object
         repeatable: true
         constraints:
@@ -4913,14 +4913,14 @@ records:
     classUri: fdri:TimeSeriesPlanStep
     shortCode: TimeSeriesPlanStep
     properties:
-      stepNumber:
+      index:
         label:
-          - value: step number
+          - value: index
             lang: en
         description:
-          - value: The sequential number of this step within the plan.
+          - value: The sequential index of this step within the plan.
             lang: en
-        propertyUri: fdri:stepNumber
+        propertyUri: fdri:index
         kind: literal
         constraints:
           - datatype: xsd:integer


### PR DESCRIPTION
* Change Time Series Plan to consist of an ordered sequence of steps
* Each step has an order number and a reference to the data processing configuration that defines the processing for that step, and the raw JSON configuration as a string
* The Time Series Plan also has a JSON representation of the ordered list of data processing configuration ids