### PR TITLE
Tweaks for processing plans

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,7 +19,9 @@ DRAFT 0.6
 * BREAKING: Change `hasOperatingRange`, `hasSurvivalRange` and `hasSystemCapability` to nested properties
 * BREAKING: Change `interval` on `FacilityGroupMembership`, `Fault` to a nested Property
 * BREAKING: Changes made to the way that a Time-Series Plan is represented. A plan now consists of a series of steps, each with its own index number and configuration.
-* NON-BREAKING: Change `hasStructuredValue` on `ConfigurationArgument` to a repeatable property to support arguments whose value is a set of structured valeus. 
+* NON-BREAKING: Change `hasStructuredValue` on `ConfigurationArgument` to a repeatable property to support arguments whose value is a set of structured valeus.
+* NON-BREAKING: Added optional `rawConfigurtion` properties to `TimeSeriesPlan` and `ConfigurationItem` to allow the JSON source for those items to be stored as a string in the metadata store. 
+
 DRAFT 0.5
 ---------
 

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -1195,6 +1195,14 @@ records:
         kind: object
         constraints:
           - record: ConfigurationItem
+      rawConfiguration:
+        description:
+          - value: The raw configuration information in JSON format.
+            language: en
+        propertyUri: fdri:rawConfiguration
+        kind: literal
+        constraints:
+          - datatype: xsd:string
 
   ConfigurationParameter:
     label:
@@ -4909,6 +4917,18 @@ records:
         repeatable: true
         constraints:
           - record: TimeSeriesPlanStep
+      rawConfiguration:
+        label:
+          - value: raw configuration
+            lang: en
+        description:
+          - value: |
+              A JSON representation of the list of steps in this plan.
+            lang: en
+        propertyUri: fdri:rawConfiguration
+        kind: literal
+        constraints:
+          - datatype: xsd:string
 
   TimeSeriesPlanStep:
     classUri: fdri:TimeSeriesPlanStep


### PR DESCRIPTION
Additional extensions to allow the raw configuration for a TimeSeriesPlan and its child steps to be stored in the metadata store as JSON strings