### PR TITLE
Add support for using ADMS Identifiers for structured identifiers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,7 +20,7 @@ DRAFT 0.7 (Work In Progress)
   * NON-BREAKING: Added a `hasPart` property to `EnvironmentalMonitoringProgramme` and `EnvironmentalMonitoringNetwork`.
   * BREAKING: Changed the property URI of the `utilises` property of `EnvironmentalMonitoringProgramme` from `fdri:utilises` to `doo:utilises`.
   * BREAKING: Changed the property URI of the `contains` property of `EnvironmentalMonitoringNetwork` from `fdri:contains` to `doo:contains`.
- * NON-BREAKING: Added a new property `structuredIdentifier` with property URI `adms:identifier` to allow the capture of identifiers as a structured value that includes the identifier string, an optional scheme identifier and an optional reference to the Agent responsible for the scheme. This DOES NOT replace the existing `identifier`(`dct:identifier`).
+ * NON-BREAKING: Added a new property `structuredIdentifier` with property URI `adms:identifier` to the `CataloguedResource` mix-in to allow the capture of identifiers as a structured value that includes the identifier string, an optional scheme identifier and an optional reference to the Agent responsible for the scheme. This DOES NOT replace the existing `identifier`(`dct:identifier`).
 
 DRAFT 0.6
 ---------

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,7 +20,8 @@ DRAFT 0.7 (Work In Progress)
   * NON-BREAKING: Added a `hasPart` property to `EnvironmentalMonitoringProgramme` and `EnvironmentalMonitoringNetwork`.
   * BREAKING: Changed the property URI of the `utilises` property of `EnvironmentalMonitoringProgramme` from `fdri:utilises` to `doo:utilises`.
   * BREAKING: Changed the property URI of the `contains` property of `EnvironmentalMonitoringNetwork` from `fdri:contains` to `doo:contains`.
- 
+ * NON-BREAKING: Added a new property `structuredIdentifier` with property URI `adms:identifier` to allow the capture of identifiers as a structured value that includes the identifier string, an optional scheme identifier and an optional reference to the Agent responsible for the scheme. This DOES NOT replace the existing `identifier`(`dct:identifier`).
+
 DRAFT 0.6
 ---------
 

--- a/doc/high-level-catalog-structure.md
+++ b/doc/high-level-catalog-structure.md
@@ -117,6 +117,12 @@ The property `fdri:originatingFacility` can be used to reference the `Environmen
 
 The property `fdri:originatingProgramme` can be used to reference the `EnvironmentalMonitoringProgramme` from which observations contained in the dataset have come. This provides a more direct way to group datasets from the same programme than going via the `fdri:ProgrammeCatalog`
 
+Identifiers for catalog resources can be specified either as a simple string identifier using the `dct:identifier` property, or as a complex property using the `adms:identifier` property. The latter property is used to reference an `adms:Identifier` resource with the following properties:
+
+* `skos:notation` - the identifier string
+* `dct:conformsTo` - the identifier of the schema that the identifier belongs to
+* `adms:schemaAgency` - the Agent (typically an Organisation), that is responsible for the maintenance of the identifier schema.
+
 > **NOTE**
 > The use of dataset-level quality metric observations can be reserved for aggregate metrics such as data availability metrics. Row-level metrics could (and arguably should) be managed in the underlying data store.
 

--- a/doc/high-level-catalog-structure.md
+++ b/doc/high-level-catalog-structure.md
@@ -147,6 +147,10 @@ The property `fdri:originatingProgramme` can be used to reference the `Environme
   class TimeSeriesDataset["fdri:TimeSeriesDataset"]
   class DatasetSeries["dcat:DatasetSeries"]
   class ProcessingLevel["fdri:ProcessingLevel"]
+  class Identifier["adms:Identifier"] {
+    skos_notation: xsd:string
+    dct_conformsTo: xsd:string
+  }
   class Dataset {
     dct_accrualPeriodicity: dcterms:Frequency
     dct_temporal: dct:PeriodOfTime
@@ -187,9 +191,11 @@ The property `fdri:originatingProgramme` can be used to reference the `Environme
   ObservationDataset --> Facility: fdri_originatingFacility
   ObservationDataset --> Site: fdri_originatingSite
   ObservationDataset --> Program: fdri_originatingProgramme
-  ObservationDataset --> ProcessingLevel: processingLevel
+  ObservationDataset --> ProcessingLevel: fdri_processingLevel
+  CatalogResource --> Identifier: adms_identifier
   CatalogResource --> Agent: dct_creator
   CatalogResource --> Agent: dct_publisher
+  Identifer --> Agent: adms_schemaAgency
   DatasetSeries --|> Dataset
   Dataset --> DatasetSeries: dcat_inSeries
   CatalogResource --> Concept: dct_type

--- a/owl/adms.ttl
+++ b/owl/adms.ttl
@@ -1,0 +1,187 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<http://www.w3.org/ns/adms>
+    <http://purl.org/dc/terms/issued> "2023-04-05" ;
+    <http://purl.org/dc/terms/license> <https://creativecommons.org/licenses/by/4.0/> ;
+    <http://purl.org/dc/terms/mediator> [
+        <http://xmlns.com/foaf/0.1/homepage> <https://semic.eu> ;
+        <http://xmlns.com/foaf/0.1/name> "Semantic Interoperability Community (SEMIC)"
+    ] ;
+    a <http://www.w3.org/2002/07/owl#Ontology> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "adms"@en, "adms"@nl ;
+    <http://www.w3.org/2001/02pd/rec54#editor> [
+        a <http://xmlns.com/foaf/0.1/Person> ;
+        <http://xmlns.com/foaf/0.1/firstName> "Bert" ;
+        <http://xmlns.com/foaf/0.1/lastName> "Van Nuffelen" ;
+        <http://xmlns.com/foaf/0.1/mbox> <mailto:bert.van.nuffelen@tenforce.com> ;
+        <https://schema.org/affiliation> [
+            <http://xmlns.com/foaf/0.1/name> "TenForce"
+        ]
+    ], [
+        a <http://xmlns.com/foaf/0.1/Person> ;
+        <http://xmlns.com/foaf/0.1/firstName> "Natasa" ;
+        <http://xmlns.com/foaf/0.1/lastName> "Sofou"
+    ], [
+        a <http://xmlns.com/foaf/0.1/Person> ;
+        <http://xmlns.com/foaf/0.1/firstName> "Pavlina" ;
+        <http://xmlns.com/foaf/0.1/lastName> "Fragkou" ;
+        <https://schema.org/affiliation> [
+            <http://xmlns.com/foaf/0.1/name> "SEMIC EU"
+        ]
+    ], [
+        a <http://xmlns.com/foaf/0.1/Person> ;
+        <http://xmlns.com/foaf/0.1/firstName> "Makx" ;
+        <http://xmlns.com/foaf/0.1/lastName> "Dekkers"
+    ] ;
+    <http://xmlns.com/foaf/0.1/maker> [
+        a <http://xmlns.com/foaf/0.1/Person> ;
+        <http://xmlns.com/foaf/0.1/firstName> "Pavlina" ;
+        <http://xmlns.com/foaf/0.1/lastName> "Fragkou" ;
+        <https://schema.org/affiliation> [
+            <http://xmlns.com/foaf/0.1/name> "SEMIC EU"
+        ]
+    ] .
+
+<http://www.w3.org/ns/adms#Asset>
+    a <http://www.w3.org/2002/07/owl#Class> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "An abstract entity that reflects the intellectual content of the asset and represents those characteristics of the asset that are independent of its physical embodiment. This abstract entity combines the FRBR entities work (a distinct intellectual or artistic creation) and expression (the intellectual or artistic realization of a work)"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Asset"@en .
+
+<http://www.w3.org/ns/adms#AssetDistribution>
+    a <http://www.w3.org/2002/07/owl#Class> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "A particular physical embodiment of an Asset, which is an example of the FRBR entity manifestation (the physical embodiment of an expression of a work)."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Asset Distribution"@en .
+
+<http://www.w3.org/ns/adms#AssetRepository>
+    a <http://www.w3.org/2002/07/owl#Class> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "A system or service that provides facilities for storage and maintenance of descriptions of Assets and Asset Distributions, and functionality that allows users to search and access these descriptions. An Asset Repository will typically contain descriptions of several Assets and related Asset Distributions."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Asset repository"@en .
+
+<http://www.w3.org/ns/adms#Identifier>
+    a <http://www.w3.org/2002/07/owl#Class> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "This is based on the UN/CEFACT Identifier class."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "Identifier"@en .
+
+<http://www.w3.org/ns/adms#identifier>
+    a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "Links a resource to an adms:Identifier class."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "identifier"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/adms#Identifier> .
+
+<http://www.w3.org/ns/adms#includedAsset>
+    a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "An Asset that is contained in the Asset being described, e.g. when there are several vocabularies defined in a single document."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/adms#Asset> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "included asset"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/adms#Asset> .
+
+<http://www.w3.org/ns/adms#interoperabilityLevel>
+    a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "The interoperability level for which the Asset is relevant."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/adms#Asset> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "interoperability level"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2004/02/skos/core#Concept> .
+
+<http://www.w3.org/ns/adms#last>
+    a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "A link to the current or latest version of the Asset."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "last"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/1999/xhtml/vocab#last> .
+
+<http://www.w3.org/ns/adms#next>
+    a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "A link to the next version of the Asset."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "next"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/1999/xhtml/vocab#next> .
+
+<http://www.w3.org/ns/adms#prev>
+    a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "A link to the previous version of the Asset."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "prev"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> <http://www.w3.org/1999/xhtml/vocab#prev> .
+
+<http://www.w3.org/ns/adms#representationTechnique>
+    a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "More information about the format in which an Asset Distribution is released. This is different from the file format as, for example, a ZIP file (file format) could contain an XML schema (representation technique)."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "representation technique"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2004/02/skos/core#Concept> .
+
+<http://www.w3.org/ns/adms#sample>
+    a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "Links to a sample of an Asset (which is itself an Asset)."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "sample"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+
+<http://www.w3.org/ns/adms#schemeAgency>
+    a <http://www.w3.org/2002/07/owl#DatatypeProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "The name of the agency that issued the identifier."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "This property is deprecated because in in HTML specification another URI was used." ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/adms#Identifier> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "schema agency"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Literal> ;
+    <http://www.w3.org/2002/07/owl#deprecated> "true" ;
+    <http://www.w3.org/2002/07/owl#equivalentProperty>  <http://www.w3.org/ns/adms#schemaAgency> ;
+    <http://purl.org/dc/terms/isReplacedBy> <http://www.w3.org/ns/adms#schemaAgency> .
+
+<http://www.w3.org/ns/adms#schemaAgency>
+    a <http://www.w3.org/2002/07/owl#DatatypeProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "The name of the agency that issued the identifier."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/ns/adms#Identifier> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "schema agency"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Literal> .
+
+<http://www.w3.org/ns/adms#status>
+    a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "The status of the Asset in the context of a particular workflow process."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "status"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2004/02/skos/core#Concept> .
+
+<http://www.w3.org/ns/adms#supportedSchema>
+    a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "A schema according to which the Asset Repository can provide data about its content, e.g. ADMS."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "supported schema"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/ns/adms#Asset> .
+
+<http://www.w3.org/ns/adms#translation>
+    a <http://www.w3.org/2002/07/owl#ObjectProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "Links Assets that are translations of each other."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "translation"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Resource> .
+
+<http://www.w3.org/ns/adms#versionNotes>
+    a <http://www.w3.org/2002/07/owl#DatatypeProperty> ;
+    <http://www.w3.org/2000/01/rdf-schema#comment> "A description of changes between this version and the previous version of the Asset."@en ;
+    <http://www.w3.org/2000/01/rdf-schema#domain> <http://www.w3.org/2000/01/rdf-schema#Resource> ;
+    <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://www.w3.org/ns/adms> ;
+    <http://www.w3.org/2000/01/rdf-schema#label> "version notes"@en ;
+    <http://www.w3.org/2000/01/rdf-schema#range> <http://www.w3.org/2000/01/rdf-schema#Literal> .
+

--- a/owl/catalog-v001.xml
+++ b/owl/catalog-v001.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="Imports Wizard Entry" name="http://www.w3.org/ns/adms" uri="adms.ttl"/>
     <uri id="Imports Wizard Entry" name="https://digital.ceh.ac.uk/ontology/doo/0.3.0/" uri="file:/home/kal/Projects/ceh/digital-objects-ontology/ontology/digital-objects-ontology.ttl"/>
     <uri id="Imports Wizard Entry" name="https://w3id.org/iadopt/ont/1.0.3" uri="iadopt-1.0.3.ttl"/>
     <uri id="User Entered Import Resolution" name="http://xmlns.com/foaf/0.1/" uri="foaf.rdf"/>

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -21,6 +21,7 @@
                                         owl:imports spatialrelations: ,
                                                     <http://www.opengis.net/ont/geosparql/1.1> ,
                                                     <http://www.w3.org/2006/time#2016> ,
+                                                    <http://www.w3.org/ns/adms> ,
                                                     <http://www.w3.org/ns/dcat3> ,
                                                     ssn:ext ,
                                                     <http://www.w3.org/ns/ssn/systems/> ,
@@ -2773,6 +2774,11 @@ geo:SpatialThing rdf:type owl:Class ;
 dcat:Resource rdfs:subClassOf [ rdf:type owl:Restriction ;
                                 owl:onProperty :hasAnnotation ;
                                 owl:minCardinality "0"^^xsd:nonNegativeInteger
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty <http://www.w3.org/ns/adms#identifier> ;
+                                owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+                                owl:onClass <http://www.w3.org/ns/adms#Identifier>
                               ] .
 
 

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -1506,6 +1506,7 @@ records:
       - WithLabelAndComment
       - WithPublicationMetadata
       - WithAnnotations
+      - CataloguedResource
     extends: Thing
     properties:
       accessRights:
@@ -1553,18 +1554,6 @@ records:
         repeatable: true
         constraints:
           - record: Distribution
-      identifier:
-        label:
-          - value: identifier
-            lang: en
-        description:
-          - value: A unique identifier of the dataset.
-            lang: en
-        propertyUri: dct:identifier
-        kind: literal
-        repeatable: true
-        constraints:
-          - datatype: xsd:string
       inSeries:
         label:
           - value: in series

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -1,5 +1,7 @@
 base: http://fdri.ceh.ac.uk/records/metadata/
 prefixes:
+  - prefix: adms
+    uri: http://www.w3.org/ns/adms#
   - prefix: dcat
     uri: http://www.w3.org/ns/dcat#
   - prefix: dct
@@ -66,6 +68,19 @@ mixins:
         repeatable: true
         constraints:
           - datatype: xsd:string
+      structuredIdentifier:
+        label:
+          - value: structured identifier
+            lang: en
+        description:
+          - value: |
+              An identifier of the resource being described or cataloged which is compliant with the W3C Asset Description Metadata Schema (ADMS) specification.
+            lang: en
+        propertyUri: adms:identifier
+        kind: object
+        repeatable: true
+        constraints:
+          - record: Identifier
 
   WithObservableProperties:
     label:
@@ -3369,6 +3384,54 @@ records:
           - record: Array
           - record: Dimension
           - record: GriddedContainer
+
+  Identifier:
+    label:
+      - value: Identifier
+        lang: en
+    description:
+      - value: |
+          An identifier in a particular context, consisting of the content string that is the identifier;
+          an optional identifier for the identifier scheme;
+          and an optional identifier for the agency that manages the identifier scheme.
+        lang: en
+    classUri: adms:Identifier
+    shortCode: Identifier
+    properties:
+      notation:
+        label:
+          - value: notation
+            lang: en
+        description:
+          - value: The content string that is the identifier.
+            lang: en
+        propertyUri: skos:notation
+        kind: literal
+        required: true
+        constraints:
+          - datatype: xsd:string
+      conformsTo:
+        label:
+          - value: conforms to
+            lang: en
+        description:
+          - value: An identifier for the identifier scheme that the identifier conforms to.
+            lang: en
+        propertyUri: dct:conformsTo
+        kind: literal
+        constraints:
+          - datatype: xsd:string
+      schemaAgency:
+        label:
+          - value: schema agency
+            lang: en
+        description:
+          - value: The agency that manages the identifier scheme.
+            lang: en
+        propertyUri: dct:schemaAgency
+        kind: object
+        constraints:
+          - record: Agent
 
   IndexedItem:
     label:

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -3417,7 +3417,7 @@ records:
         description:
           - value: The agency that manages the identifier scheme.
             lang: en
-        propertyUri: dct:schemaAgency
+        propertyUri: adms:schemaAgency
         kind: object
         constraints:
           - record: Agent


### PR DESCRIPTION
Update the OWL ontology to include the ADMS ontology and allow use of adms:identifier on a dcat:Resource.
Update the CataloguedResource mixin in the schema to add a new `structuredIdentifier` property (mapped to the property URI adms:identifier).
This approach allows the use of both string literal identifiers via dct:identifier/identifier and/or structured identifiers via adms:identifier/structuredIdentifier. 