### PR TITLE
Add properties for the relative location of an EMPlatform

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,7 +20,8 @@ DRAFT 0.7 (Work In Progress)
   * NON-BREAKING: Added a `hasPart` property to `EnvironmentalMonitoringProgramme` and `EnvironmentalMonitoringNetwork`.
   * BREAKING: Changed the property URI of the `utilises` property of `EnvironmentalMonitoringProgramme` from `fdri:utilises` to `doo:utilises`.
   * BREAKING: Changed the property URI of the `contains` property of `EnvironmentalMonitoringNetwork` from `fdri:contains` to `doo:contains`.
- * NON-BREAKING: Added a new property `structuredIdentifier` with property URI `adms:identifier` to the `CataloguedResource` mix-in to allow the capture of identifiers as a structured value that includes the identifier string, an optional scheme identifier and an optional reference to the Agent responsible for the scheme. This DOES NOT replace the existing `identifier`(`dct:identifier`).
+* NON-BREAKING: Added a new property `structuredIdentifier` with property URI `adms:identifier` to the `CataloguedResource` mix-in to allow the capture of identifiers as a structured value that includes the identifier string, an optional scheme identifier and an optional reference to the Agent responsible for the scheme. This DOES NOT replace the existing `identifier`(`dct:identifier`).
+* NON-BREAKING: Updated the model for `fdri:EnvironmentalMonitoringPlatform` to allow properties to specify the relative position of the platform with respect to a representative point location of the site that hosts the platform.
 
 DRAFT 0.6
 ---------

--- a/doc/emf.md
+++ b/doc/emf.md
@@ -191,6 +191,24 @@ EMFacility <|-- EMSite
 > [!NOTE]
 > By mapping both `fdri:EnvironmentalMonitoringSite` and `fdri:EnvironmentalMonitoringPlatform` to `sosa:Platform`, a deployment of a sensor can be registered at the site level without having to model the detail of the physical infrastructure at the site, but that the model still has the flexibility to represent more detailed information if it is available and if deemed desirable to do so.
 
+For static infrastructure, the type defines properties which can be used to specify the location of the `fdri:EnvironmentalMonitoringPlatform` relative to a representative point for the `fdri:EnvironmentalMonitoringSite` that hosts the platform.
+
+```mermaid
+---
+  config:
+    class:
+      hideEmptyMembersBox: true
+---
+classDiagram
+class EMFacility["fdri:EnvironmentalMonitoringFacility"]
+class EMPlatform["fdri:EnvironmentalMonitoringPlatform"] {
+  fdri:eastOffset: xsd:decimal
+  fdri:northOffset: xsd:decimal
+  fdri:verticalOffset: xsd:decimal
+  fdri:azimuth: xsd:decimal
+}
+EMFacility <|-- EMPlatform
+```
 
 #### EnvironmentalMonitoringSystem
 

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -1518,7 +1518,23 @@ The derived classes `fdri:EnvironmentalMonitoringSite`, `fdri:EnvironmentalMonit
 ###  http://fdri.ceh.ac.uk/vocab/metadata/EnvironmentalMonitoringPlatform
 :EnvironmentalMonitoringPlatform rdf:type owl:Class ;
                                  rdfs:subClassOf :EnvironmentalMonitoringFacility ,
-                                                 sosa:Platform ;
+                                                 sosa:Platform ,
+                                                 [ rdf:type owl:Restriction ;
+                                                   owl:onProperty :azimuth ;
+                                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                                 ] ,
+                                                 [ rdf:type owl:Restriction ;
+                                                   owl:onProperty :eastOffset ;
+                                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                                 ] ,
+                                                 [ rdf:type owl:Restriction ;
+                                                   owl:onProperty :northOffset ;
+                                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                                 ] ,
+                                                 [ rdf:type owl:Restriction ;
+                                                   owl:onProperty :verticalOffset ;
+                                                   owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                                 ] ;
                                  rdfs:comment """A piece of infrastructure at a site that is used in the monitoring of the environment at that site.
 
 An Environmental Monitoring Platform may be a physical piece of infrastructure such as a post in the ground, a raised platform or a hole in the ground. It may also be used to represent a \"slot\" in the site infrastructure to which sensors may be serially deployed over time in order to monitor the same phenomenon.

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -2367,6 +2367,47 @@ records:
         kind: object
         constraints:
           - record: EnvironmentalMonitoringSite
+      eastOffset:
+        label:
+          - value: east offset
+            lang: en
+        description:
+          - value: The eastward offset of the platform from the representative point location of the site that contains the platform (in metres).
+            lang: en
+        propertyUri: fdri:eastOffset
+        kind: literal
+        constraints:
+          - datatype: xsd:decimal
+      northOffset:
+        label:
+          - value: north offset
+            lang: en
+        description:
+          - value: The northward offset of the platform from the representative point location of the site that contains the platform (in metres).
+            lang: en
+        propertyUri: fdri:northOffset
+        kind: literal
+        constraints:
+          - datatype: xsd:decimal
+      verticalOffset:
+        label:
+          - value: vertical offset
+            lang: en
+        description:
+          - value: The vertical offset of the platform from the representative point location of the site that contains the platform (in metres).
+            lang: en
+        propertyUri: fdri:verticalOffset
+        kind: literal
+        constraints:
+          - datatype: xsd:decimal
+      azimuth:
+        label:
+          - value: azimuth
+            lang: en
+        propertyUri: fdri:azimuth
+        kind: literal
+        constraints:
+          - datatype: xsd:decimal
 
   EnvironmentalMonitoringProgramme:
     label:


### PR DESCRIPTION
Add `fdri:eastOffset`, `fdri:northOffset`, `fdri:verticalOffset` and `fdri:azimuth` as a means of specifying the relative position of an EMPlatform at a site. The position should be specified relative to the representative point location of the containing EMSite.