### PR TITLE
Add support for mapping measures to column names on a distribution

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ DRAFT 0.7 (Work In Progress)
   * BREAKING: Changed the property URI of the `contains` property of `EnvironmentalMonitoringNetwork` from `fdri:contains` to `doo:contains`.
 * NON-BREAKING: Added a new property `structuredIdentifier` with property URI `adms:identifier` to the `CataloguedResource` mix-in to allow the capture of identifiers as a structured value that includes the identifier string, an optional scheme identifier and an optional reference to the Agent responsible for the scheme. This DOES NOT replace the existing `identifier`(`dct:identifier`).
 * NON-BREAKING: Updated the model for `fdri:EnvironmentalMonitoringPlatform` to allow properties to specify the relative position of the platform with respect to a representative point location of the site that hosts the platform.
+* NON-BREAKING: Added support for specifying the mapping between the measures that a dataset provides and the columns or property names for those measures in a distribution of the dataset.
 
 DRAFT 0.6
 ---------

--- a/doc/dataset-distributions.md
+++ b/doc/dataset-distributions.md
@@ -1,0 +1,38 @@
+## Dataset Distributions
+
+A dataset distribution provides access to the content of the dataset either as a direct download or via a download service. A dataset may have multiple distributions - e.g. when the data is available in multiple formats or from multiple mirrors.
+
+The FDRI Ontology extends the DCAT ontology and supports all of the [properties described for distributions by that specification](https://www.w3.org/TR/vocab-dcat-3/#Class:Distribution).
+
+The FDRI Schema currently supports a limited subset of the full ontology. Specifically, it currently allows the following properties on a Distribution record:
+
+* `accessUrl` - providing the URL via which the distribution can be accessed or downloaded.
+* `format` - a reference to a SKOS concept which defines the file format of the distribution.
+* `hasMeasureSchema` - relates the distribution to a mapping of column/property name to the measure that is provided by that column or property in the distribution. Described in more detail below.
+
+### Measure Schema
+
+The FDRI ontology provides a means for mapping the measures recorded in a dataset distribution to the names of the properties/columns in the dataset distribution that provide those measures. Although formats such as ZARR and NetCDF provide such functionality in the file header structures, other formats such as CSV and parquet provide limited or no such functionality and so this structure provides a simple means to convey this useful information to the data user regardless of the format of the distribution. The following class diagram shows the Measure Schema and how it relates to Distributions.
+
+```mermaid
+classDiagram
+class Distribution["dcat:Distributionn"]
+class MeasureColumn["fdri:MeasureColumn"] {
+    fdri:columnName: xsd:string
+}
+class MeasureSchema["fdri:MeasureSchema"]
+class Standard["dct:Standard"]
+class Measure["fdri:Measure"]
+Standard <|-- MeasureSchema
+MeasureSchema --o "1..*" MeasureColumn: fdri_hasMember
+MeasureColumn --> "1" Measure: fdri_measure
+Distribution --> "0..1" MeasureSchema: fdri_conformsToMeasureSchema
+```
+
+A `dcat:Distribtion` can be optionally related to one `fdri:MeasureSchema` which defines the column/property mappings for that distribution. This uses the property `fdri:conformsToMeasureSchema` which is declared as a sub-property of `dct:conformsTo`.
+
+An `fdri:MeasureSchema` is has one or more member `fdri:MeasureColumn` resources, each of which specify exactly one column name (as a string), and one `fdri:Measure`. `fdri:MeasureSchema` is declared as a sub-class of `dct:Standard`.
+
+### Hive partition URLs
+
+In the FDRI system there are datasets which are available as a partition of a larger dataset using Hive partitioning. It is recommended that the access URL for such a dataset should be the lowest level of partition that provides access to the full range of data in the dataset. The format specifier for the distribution should be the format of the data within each leaf partition.

--- a/doc/toc.md
+++ b/doc/toc.md
@@ -15,6 +15,7 @@
 * [Time-Series Dataset Model](time-series-dataset.md)
 * [Flag Columns](flag-columns.md)
 * [Gridded Dataset Model](gridded-data.md)
+* [Dataset Distributions](dataset-distributions.md)
 * [Annotations on Catalogued Resources](annotations.md)
 * [Provenance and Activity Model](provenance-and-activity.md)
 * [Variables and Measures](variables.md)

--- a/owl/fdri-metadata.ttl
+++ b/owl/fdri-metadata.ttl
@@ -160,6 +160,13 @@ geo:location rdf:type owl:AnnotationProperty ;
                              rdfs:label "configiuration property scheme"@en .
 
 
+###  http://fdri.ceh.ac.uk/vocab/metadata/conformsToMeasureSchema
+:conformsToMeasureSchema rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf dct:conformsTo ;
+                         rdfs:comment "Relates a resource to the MeasureSchema which defines how the columns/properties contained within that resource are mapped to Measures."@en ;
+                         rdfs:label "conforms to measure schema"@en .
+
+
 ###  http://fdri.ceh.ac.uk/vocab/metadata/contains
 :contains rdf:type owl:ObjectProperty .
 
@@ -253,6 +260,7 @@ geo:location rdf:type owl:AnnotationProperty ;
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/hasMember
 :hasMember rdf:type owl:ObjectProperty ;
+           rdfs:range :MeasureSchema ;
            rdfs:comment "Represents a simple group-membership relationship in which the subject of the statement is the group and the object of the statement the group member"@en ;
            rdfs:label "has member"@en .
 
@@ -323,7 +331,6 @@ When `fdri:hasValue` is present on an item, this property SHOULD NOT be present 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/measure
 :measure rdf:type owl:ObjectProperty ;
-         rdfs:domain :ObservationDataset ;
          rdfs:range :Measure ;
          rdfs:comment "Relates an ObservationDataset to a Measure that the dataset provides values for."@en ;
          rdfs:label "measure"@en .
@@ -528,6 +535,11 @@ When this property is used to convey a datatype for `minValue`, `maxValue` and/o
                rdfs:domain :ObservationDataset ;
                rdfs:comment "Relates a resource to the activity that modified the resource in some way."@en ;
                rdfs:label "was modified by"@en .
+
+
+###  http://purl.org/dc/terms/conformsTo
+dct:conformsTo rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf dct:relation .
 
 
 ###  http://purl.org/dc/terms/replaces
@@ -2118,6 +2130,30 @@ A current configuration MAY consist of multiple `fdri:ConfigurationItem` instanc
                          ] ;
          rdfs:comment "Represents the measurement of a variable (fdri:variable) as recorded in a dataset using some consistent measurement unit (fdri:hasUnit) and an optional aggregation (fdri:aggregation)." ;
          rdfs:label "Measure"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/MeasureColumn
+:MeasureColumn rdf:type owl:Class ;
+               rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                 owl:onProperty :measure ;
+                                 owl:cardinality "1"^^xsd:nonNegativeInteger
+                               ] ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :columnName ;
+                                 owl:cardinality "1"^^xsd:nonNegativeInteger
+                               ] ;
+               rdfs:comment "Relates an fdri:Measure to the name of a column or property that stores observations of that measure."@en ;
+               rdfs:label "Measure Column"@en .
+
+
+###  http://fdri.ceh.ac.uk/vocab/metadata/MeasureSchema
+:MeasureSchema rdf:type owl:Class ;
+               rdfs:subClassOf dct:Standard ,
+                               [ rdf:type owl:Restriction ;
+                                 owl:onProperty :hasMember ;
+                                 owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                 owl:onClass :MeasureColumn
+                               ] .
 
 
 ###  http://fdri.ceh.ac.uk/vocab/metadata/MeasureScheme

--- a/schema/fdri.recordspec.yaml
+++ b/schema/fdri.recordspec.yaml
@@ -1541,6 +1541,8 @@ records:
         propertyUri: dct:conformsTo
         kind: object
         repeatable: true
+        constraints:
+          - record: Standard
       distribution:
         label:
           - value: distribution
@@ -1924,6 +1926,19 @@ records:
         required: true
         constraints:
           - record: Concept
+      conformsToMeasureSchema:
+        label:
+          - value: conforms to measure schema
+            lang: en
+        description:
+          - value: A reference to the fdri:MeasureSchema which defines the structure and semantics of the columns or properties of the distribution.
+            lang: en
+        propertyUri: fdri:hasMeasureSchema
+        kind: object
+        repeatable: false
+        constraints:
+          - record: MeasureSchema
+      
 
   Entity:
     label:
@@ -3610,6 +3625,67 @@ records:
         constraints:
           - record: Variable
   
+  MeasureColumn:
+    label:
+      - value: Measure Column
+        lang: en
+    description:
+      - value: Relates a column or property name in a dataset to the measure that it provides values for.
+        lang: en
+    classUri: fdri:MeasureColumn
+    shortCode: MeasureColumn
+    properties:
+      columnName:
+        label:
+          - value: column name
+            lang: en
+        description:
+          - value: The name of the column in the dataset that contains the measure values.
+            lang: en
+        propertyUri: fdri:columnName
+        kind: literal
+        required: true
+        constraints:
+          - datatype: xsd:string
+      measure:
+        label:
+          - value: measure
+            lang: en
+        description:
+          - value: A reference to the `fdri:Measure` that describes the measure values in the column.
+            lang: en
+        propertyUri: fdri:measure
+        kind: object
+        required: true
+        constraints:
+          - record: Measure
+
+  MeasureSchema:
+    label:
+      - value: Measure Schema
+        lang: en
+    description:
+      - value: A collection of name to measure mappings (fdri:MeasureColumn) that defines how the columns or properties of the annotated dataset relate to the measures that they provide values for.
+        lang: en
+    extends: Standard
+    classUri: fdri:MeasureSchema
+    shortCode: MeasureSchema
+    properties:
+      hasMember:
+        label:
+          - value: has member
+            lang: en
+        description:
+          - value: Relates the containing `MeasureSchema` to a `fdri:MeasureColumn` that describes the measure values provided by a column in the annotated dataset.
+            lang: en
+        propertyUri: fdri:hasMember
+        kind: object
+        embedded: true
+        required: true
+        repeatable: true
+        constraints:
+          - record: MeasureColumn
+
   MeasureScheme:
     label:
       - value: Measure Scheme
@@ -4568,6 +4644,17 @@ records:
     extends: ConceptScheme
     classUri: fdri:SoilTypeScheme
     shortCode: SoilTypeScheme
+
+  Standard:
+    label:
+      - value: Standard
+        lang: en
+    description:
+      - value: A reference point against which other things can be evaluated or compared.
+        lang: en
+    classUri: dct:Standard
+    shortCode: Standard
+    extends: Thing
 
   StaticDeployment:
     label:


### PR DESCRIPTION
* Add a new type `fdri:MeasureSchema` which is `rdfs:subClassOf` `dct:Standard`
* Add a new type `fdri:MeasureColumn` which maps an `fdri:Measure` to a column or property name.
* A MeasureSchema must reference one or more MeasureColumns.
* A distribution may reference the MeasureSchema that defines how measures are mapped to columns/properties for that distribution using the property `fdri:conformsToMeasureSchema` which is an `rdfs:subPropertyOf` `dct:conformsTo`.
* Added some basic documentation about distributions, including this new additional structure.